### PR TITLE
fix: remove anotation managed-by

### DIFF
--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -4,7 +4,6 @@ kind: HelmRelease
 metadata:
   name: metrics-server
   namespace: kube-system
-  app.kubernetes.io/managed-by: helm
   annotations:
     meta.helm.sh/release-name: "metrics-server"
     meta.helm.sh/release-namespace: "kube-system"


### PR DESCRIPTION
# Describe the bug

```
cluster-apps-metrics-server                     False           False   HelmRelease/kube-system/metrics-server dry-run failed, error: failed to create typed patch object (kube-system/metrics-server; helm.toolkit.fluxcd.io/v2beta1, Kind=HelmRelease): .metadata.app.kubernetes.io/managed-by: field not declared in schema
```

# Steps to reproduce

Use the repository in commit `8528f9ad7a9c961a87814fa9088db4a13474fea7`

# Expected behavior

Flux can reconcíliate the resources