### PR TITLE
feat(renovate): pin all docker/helm deps by digest

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -36,6 +36,20 @@
       overrideDepName: "{{packageName}}",
     },
     {
+      description: "Pin all docker / helm (incl. Flux OCIRepository) deps by digest",
+      matchDatasources: ["docker", "helm"],
+      pinDigests: true,
+    },
+    {
+      description: "Group the initial digest-pinning sweep into a single PR and allow it to run on any day (the global schedule is weekend-only).",
+      matchDatasources: ["docker", "helm"],
+      matchUpdateTypes: ["pinDigest"],
+      groupName: "pin all digests",
+      commitMessageTopic: "{{{groupName}}}",
+      schedule: ["at any time"],
+      automerge: false,
+    },
+    {
       description: "Flux Operator Group",
       groupName: "flux-operator",
       matchDatasources: ["docker"],


### PR DESCRIPTION
## Summary

- Enable `pinDigests: true` for `matchDatasources: [docker, helm]` so Renovate adds `@sha256:...` to every `image:` tag, every HelmRelease `repository`+`tag` pair, and every Flux `OCIRepository.spec.ref.tag`.
- Group the initial pin-digest sweep into one PR (`groupName: "pin all digests"`) and override the global weekend-only schedule with `schedule: ["at any time"]` so it runs on the next manual `workflow_dispatch` instead of waiting until Saturday.

## Why

Audit of `home-ops` showed 31 image references and 49 OCIRepository charts without a digest pinned (see Vikunja tasks #36 and #37). Pinning by digest gives true immutability and makes the supply-chain story honest.

## How to roll out

1. Merge this PR into `main`.
2. Manually dispatch the Renovate workflow:
   ```bash
   gh workflow run Renovate -f dryRun=false -f logLevel=info
   ```
3. Renovate will open a single PR titled "pin all digests" with ~80 deps pinned. Review, merge.
4. Future digest bumps follow the default per-image flow (only the initial sweep is grouped).

## Test plan

- [ ] After merge, run the workflow with `dryRun=true` first and inspect the log output to confirm Renovate intends to pin all expected deps.
- [ ] Then run with `dryRun=false` to open the actual sweep PR.
- [ ] Spot-check the sweep PR diff: every existing tag should now be followed by `@sha256:...` (image refs) or have a sibling `digest:` field (OCIRepository).