### PR TITLE
fix(renovate): scope pinDigests to kubernetes/** so helmfile bootstrap doesn't abort the grouped branch

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -36,13 +36,15 @@
       overrideDepName: "{{packageName}}",
     },
     {
-      description: "Pin all docker / helm (incl. Flux OCIRepository) deps by digest",
+      description: "Pin all docker / helm (incl. Flux OCIRepository) deps by digest. Restricted to kubernetes/** so the helmfile bootstrap templates (templates/**) are excluded — Renovate's helmfile manager fails to write back digests on .yaml.j2 files and aborts the whole grouped branch.",
       matchDatasources: ["docker", "helm"],
+      matchFileNames: ["kubernetes/**"],
       pinDigests: true,
     },
     {
       description: "Group the initial digest-pinning sweep into a single PR and allow it to run on any day (the global schedule is weekend-only).",
       matchDatasources: ["docker", "helm"],
+      matchFileNames: ["kubernetes/**"],
       matchUpdateTypes: ["pinDigest"],
       groupName: "pin all digests",
       commitMessageTopic: "{{{groupName}}}",


### PR DESCRIPTION
## Summary

Limit the `pinDigests` rules from #917 to `matchFileNames: ["kubernetes/**"]`. This prevents Renovate's helmfile manager from running its broken digest-writeback against the `templates/config/bootstrap/helmfile.d/*.yaml.j2` files, which was aborting the entire grouped `pin all digests` branch.

## Why

After #917 was merged and the workflow dispatched, no PR opened. Debug log showed:

```
DEBUG: Digest is not updated
  packageFile=templates/config/bootstrap/helmfile.d/01-apps.yaml.j2
  depName=ghcr.io/coredns/charts/coredns
  manager=helmfile
  expectedValue=sha256:3a1b37d1...
  foundValue=undefined
WARN: Error updating branch: update failure (branch=renovate/pin-all-digests)
```

The helmfile manager can update `version: 1.45.2` lines fine (we have several merged PRs that did exactly that), but the **add-a-new-`digest:`-field** writeback fails on `.yaml.j2` files with custom Jinja delimiters. Because the digest sweep is grouped, that single failure poisons the whole branch.

## Fix

Add `matchFileNames: ["kubernetes/**"]` to both the `pinDigests: true` rule and the grouping rule. This restricts digest-pinning to:

- Plain `image:` in Pod/CronJob/DaemonSet
- HelmRelease values (`repository:` + `tag:`)
- Flux `OCIRepository.spec.ref.tag`

…all of which live under `kubernetes/`. The bootstrap helmfile templates under `templates/` keep their existing version-bump management (no regression) and just don't get digest-pinned.

## Test plan

- [ ] Merge.
- [ ] Dispatch the workflow:
  ```
  gh workflow run Renovate -f dryRun=false -f logLevel=info
  ```
- [ ] Confirm a PR titled "pin all digests" opens with the ~80 deps under `kubernetes/`.