### PR TITLE
fix(renovate): match OCIRepository files by path, not by depType

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -42,9 +42,9 @@
       pinDigests: true,
     },
     {
-      description: "Disable digest pinning for Flux OCIRepository. Renovate writes the digest back into the `tag` field as `vX.Y.Z@sha256:...` (Docker-image syntax), but Flux OCIRepository uses a separate `digest:` field — `tag: v1.20.2@sha256:...` is rejected by helm/source-controller as an improper version constraint. Until the upstream Flux manager learns the correct writeback, OCIRepository charts stay tag-only.",
+      description: "Disable digest pinning for Flux OCIRepository files. Renovate writes the digest back into the `tag` field as `vX.Y.Z@sha256:...` (Docker-image syntax), but Flux OCIRepository uses a separate `digest:` field — `tag: v1.20.2@sha256:...` is rejected by helm/source-controller as an improper version constraint. Match by file path (`**/ocirepository.yaml`) — the flux manager does not set `depType: OCIRepository` on these deps, so `matchDepTypes` would silently no-op.",
       matchManagers: ["flux"],
-      matchDepTypes: ["OCIRepository"],
+      matchFileNames: ["**/ocirepository.yaml"],
       pinDigests: false,
     },
     {


### PR DESCRIPTION
## Summary

The packageRule from #924 used `matchDepTypes: [OCIRepository]` to disable `pinDigests` for Flux `OCIRepository` deps. That matcher silently doesn't match anything — the flux manager only assigns `depType` values like `action`, `docker`, `github-runner`. So the rule was a no-op and Renovate kept regenerating `tag: vX.Y.Z@sha256:...` on `OCIRepository` files (e.g. on PR #925).

Switch the matcher to `matchFileNames: ["**/ocirepository.yaml"]` so the rule fires on the right files deterministically.

## Why we know `matchDepTypes` doesn't match

From the post-merge debug log (Renovate run `25488009383`):

```
"depType": "action"
"depType": "docker"
"depType": "github-runner"
```

No `OCIRepository` depType anywhere. The dep entry for cert-manager's OCIRepository chart shows `datasource: "docker"` but no `depType` at all.

## Test plan

- [ ] Merge.
- [ ] Close PR #925 (its branch carries the broken digest writes — let Renovate regenerate from scratch).
- [ ] `gh workflow run Renovate -f dryRun=false`.
- [ ] Confirm the new "pin all digests" PR contains image / HelmRelease changes only — no `OCIRepository.yaml` modifications.