### PR TITLE
fix(databases): split crunchy-pg OCIRepository into its own file

### DIFF
--- a/kubernetes/apps/databases/crunchy-pg/operator/helmrelease.yaml
+++ b/kubernetes/apps/databases/crunchy-pg/operator/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: pgo
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 6.0.1
-  url: oci://registry.developers.crunchydata.com/crunchydata/pgo
----
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/databases/crunchy-pg/operator/kustomization.yaml
+++ b/kubernetes/apps/databases/crunchy-pg/operator/kustomization.yaml
@@ -3,4 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/databases/crunchy-pg/operator/ocirepository.yaml
+++ b/kubernetes/apps/databases/crunchy-pg/operator/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: pgo
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 6.0.1
+  url: oci://registry.developers.crunchydata.com/crunchydata/pgo


### PR DESCRIPTION
## Summary

`kubernetes/apps/databases/crunchy-pg/operator/helmrelease.yaml` was the only file in `kubernetes/apps/` that inlined the `OCIRepository` definition next to the `HelmRelease` (separated by `---`). Every other chart followed the convention of a sibling `ocirepository.yaml` file. Move the `OCIRepository` to its own file and reference it from `kustomization.yaml`.

## Why

The Renovate packageRule from #926 scopes `pinDigests: false` to `matchFileNames: ["**/ocirepository.yaml"]`. The inlined OCIRepository in `helmrelease.yaml` slipped past that filter and Renovate wrote the broken Docker-image syntax on it (PR #928):

```yaml
ref:
  tag: 6.0.1@sha256:eb455efcc56d97c4b530cae03cc4af717b649cad4be82cf56ff36ab53e60c04c   # ← invalid for Flux
```

`helm template ... --version 6.0.1@sha256:...` returned `Error: improper constraint`, so `flux-local` failed.

After this split, the rule covers every OCI chart source in the repo uniformly and the next Renovate sweep won't touch this file's `tag:`.

## Test plan

- [ ] `kustomize build kubernetes/apps/databases/crunchy-pg/operator/` produces the same OCIRepository + HelmRelease pair as before.
- [ ] After merge, close PR #928 and let Renovate regenerate — the new sweep should not modify any `ocirepository.yaml`.