### PR TITLE
feat(observability): archive Alertmanager notifications into VictoriaLogs

### DIFF
--- a/kubernetes/apps/observability/alertmanager-webhook-logger/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/alertmanager-webhook-logger/app/helmrelease.yaml
@@ -19,13 +19,13 @@ spec:
               tag: "1.0"
             args:
               - -address=:6725
-              - -json=true
             probes:
               liveness: &probes
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /healthz
                     port: &port 6725
                   initialDelaySeconds: 5
                   periodSeconds: 10

--- a/kubernetes/apps/observability/alertmanager-webhook-logger/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/alertmanager-webhook-logger/app/helmrelease.yaml
@@ -14,9 +14,8 @@ spec:
         containers:
           app:
             image:
-              # TODO: pin @sha256:... once first CI build publishes
               repository: ghcr.io/oscaromeu/alertmanager-webhook-logger
-              tag: "1.0"
+              tag: 1.0@sha256:bf2103699e65ce9156f26dc1268232649cd81aa12c7bf6fec7b01eff98b4cfdf
             args:
               - -address=:6725
             probes:

--- a/kubernetes/apps/observability/alertmanager-webhook-logger/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/alertmanager-webhook-logger/app/helmrelease.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app alertmanager-webhook-logger
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  values:
+    controllers:
+      alertmanager-webhook-logger:
+        containers:
+          app:
+            image:
+              # TODO: pin @sha256:... once first CI build publishes
+              repository: ghcr.io/oscaromeu/alertmanager-webhook-logger
+              tag: "1.0"
+            args:
+              - -address=:6725
+              - -json=true
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 6725
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 5m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/observability/alertmanager-webhook-logger/app/kustomization.yaml
+++ b/kubernetes/apps/observability/alertmanager-webhook-logger/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/alertmanager-webhook-logger/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/alertmanager-webhook-logger/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: alertmanager-webhook-logger
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/alertmanager-webhook-logger/ks.yaml
+++ b/kubernetes/apps/observability/alertmanager-webhook-logger/ks.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app alertmanager-webhook-logger
+spec:
+  targetNamespace: observability
+  path: ./kubernetes/apps/observability/alertmanager-webhook-logger/app

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/config-alertmanager.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/config-alertmanager.yaml
@@ -14,6 +14,8 @@ spec:
           - name: alertname
             value: InfoInhibitor
             matchType: =
+      - receiver: vl-archive
+        continue: true
       - receiver: pushover
         matchers:
           - name: severity
@@ -41,6 +43,10 @@ spec:
 
   receivers:
     - name: blackhole
+    - name: vl-archive
+      webhookConfigs:
+        - url: http://alertmanager-webhook-logger.observability.svc.cluster.local:6725/
+          sendResolved: true
     - name: pushover
       pushoverConfigs:
         - html: true

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./alertmanager-webhook-logger/ks.yaml
   - ./fastapi/ks.yaml
   - ./fluentbit/ks.yaml
   - ./gatus/ks.yaml


### PR DESCRIPTION
## Summary

- Adds `alertmanager-webhook-logger` Deployment in `observability` (bjw-s app-template, TCP probe on `:6725`, runAsUser 65534).
- Wires a sibling route in `AlertmanagerConfig` with `continue: true` between `blackhole` and `pushover`, so every alert (except InfoInhibitor) is also forwarded to the logger.
- Logger writes structured JSON to stdout → existing fluentbit agent already ships all pod stdouts to VictoriaLogs → alert history queryable via LogsQL with \`unpack_json\`.

## Dependencies

- Requires image \`ghcr.io/oscaromeu/alertmanager-webhook-logger:1.0\` — built in [oscaromeu/containers#7](https://github.com/oscaromeu/containers/pull/7). **Merge that PR first** so CI publishes the image before Flux reconciles.
- After the image is published, pin the digest in [helmrelease.yaml](https://github.com/oscaromeu/home-ops/blob/feat/alertmanager-webhook-logger/kubernetes/apps/observability/alertmanager-webhook-logger/app/helmrelease.yaml) (\`tag: \"1.0@sha256:...\"\`) — Renovate will also do this on next run.

## Why

Alertmanager itself stores no persistent alert history (state is in-memory, lost on restart). VictoriaMetrics' \`ALERTS\` series only captures rule evaluation, not Alertmanager's notification pipeline (silences, inhibitions, grouping). The webhook bridge gives us the latter.

## Notes

- Did NOT touch Fluent Bit: the agent's tail input already matches all pod stdouts and ships to VL. The alert JSON sits inside the \`log\` field; queries use \`unpack_json\`. If we want \`alertname\`/\`severity\` as VL stream fields later, add a scoped parser filter to the agent pipeline.
- VictoriaLogs retention is currently \`14d\` — bump in \`victoria-logs/app/helmrelease.yaml\` for longer alert history.

## Test plan

- [x] After merge, verify pod is Running: \`kubectl -n observability get pods -l app.kubernetes.io/name=alertmanager-webhook-logger\`
- [x] Trigger a test alert (e.g. amtool or kill a pod) and confirm structured JSON appears in pod logs.
- [x] Query VictoriaLogs: \`k_pod_name:alertmanager-webhook-logger* | unpack_json from log\` returns alert events.
- [x] Confirm Pushover paging still works for severity=critical (route order unchanged for non-archive paths).