### PR TITLE
feat(observability): reloader annotations on victoria-alerts, victoria-logs, fluentbit

### DIFF
--- a/kubernetes/apps/observability/fluentbit/agent/helmrelease.yaml
+++ b/kubernetes/apps/observability/fluentbit/agent/helmrelease.yaml
@@ -9,6 +9,8 @@ spec:
     kind: OCIRepository
     name: fluent-bit
   values:
+    annotations:
+      reloader.stakater.com/auto: "true"
     existingConfigMap: fluentbit
     image:
       repository: cr.fluentbit.io/fluent/fluent-bit

--- a/kubernetes/apps/observability/fluentbit/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/fluentbit/aggregator/helmrelease.yaml
@@ -9,6 +9,8 @@ spec:
     kind: OCIRepository
     name: fluent-bit
   values:
+    annotations:
+      reloader.stakater.com/auto: "true"
     existingConfigMap: fluentbit
     image:
       repository: cr.fluentbit.io/fluent/fluent-bit

--- a/kubernetes/apps/observability/victoria-alerts/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-alerts/app/helmrelease.yaml
@@ -11,6 +11,8 @@ spec:
   values:
     nameOverride: "victoria-alerts"
     server:
+      annotations:
+        reloader.stakater.com/auto: "true"
       replicaCount: 1
       datasource:
         url: "http://victoria-logs-server.observability.svc.cluster.local:9428"

--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -11,6 +11,8 @@ spec:
   values:
     fullnameOverride: victoria-logs
     server:
+      annotations:
+        reloader.stakater.com/auto: "true"
       replicaCount: 1
       persistentVolume:
         enabled: true


### PR DESCRIPTION
## Summary

Add \`reloader.stakater.com/auto: \"true\"\` to chart values so Stakater Reloader auto-restarts these workloads when their referenced ConfigMaps/Secrets change.

| App | Annotation knob | Why |
|---|---|---|
| **victoria-alerts** | \`server.annotations\` | Primary driver — restart on \`victoria-alerts-server-alert-rules-config\` ConfigMap change (today's manual rollout is required to pick up rule edits) |
| **victoria-logs** | \`server.annotations\` | Future-proof; no CM/Secret today, but \`auto\` is harmless and consistent |
| **fluentbit/agent** | top-level \`annotations\` | Restart on \`fluentbit\` / \`parsers\` / \`pipelines-agent\` ConfigMap changes |
| **fluentbit/aggregator** | top-level \`annotations\` | Restart on \`fluentbit\` / \`parsers\` / \`pipelines\` ConfigMap changes + \`topic-cluster-apps-logs-certs\` Secret rotation |

## Why \`auto\` instead of explicit CM list

Auto-detects any ConfigMap/Secret the Deployment/DaemonSet uses (via envFrom, volumeMounts). Zero maintenance if we add more refs later. Same pattern already in use across most apps in the repo (gatus, default/* apps, network/* apps).

## kube-prometheus-stack/alertmanager: intentionally NOT included

Operator-managed Alertmanager has two issues:

1. The chart does not expose \`statefulSetAnnotations\` — only \`alertmanager.alertmanagerSpec.podMetadata.annotations\`. Stakater Reloader scans Deployment/StatefulSet/DaemonSet annotations only, **not** pod-template annotations.
2. The Prometheus Operator ships a \`config-reloader\` sidecar in the AM pod that watches the generated config Secret and sends SIGHUP to the AM process — graceful reload, no pod restart needed.

Adding stakater reloader here would be both ineffective (wrong place to annotate) and redundant (operator already handles it).

## Test plan

- [x] After merge, verify annotations are applied: \`kubectl -n observability get deploy,sts,ds -o jsonpath='{range .items[*]}{.metadata.name}{\"\\t\"}{.metadata.annotations.reloader\\.stakater\\.com/auto}{\"\\n\"}{end}'\` shows \`true\` for the 4 workloads.
- [x] Touch \`kubernetes/apps/observability/victoria-alerts/rules/alert-rules.yaml\` (no-op change), commit; verify victoria-alerts pod rolls.
- [x] Touch \`kubernetes/apps/observability/fluentbit/agent/pipelines/kubernetes-agent.yaml\` (no-op change), commit; verify fluent-bit agent DaemonSet rolls.