### PR TITLE
chore(ksm): restrict metricLabelsAllowlist to needed labels

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/values-kube-state-metrics.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/values-kube-state-metrics.yaml
@@ -2,9 +2,12 @@ kube-state-metrics:
   enabled: true
   fullnameOverride: kube-state-metrics
   metricLabelsAllowlist:
-    - pods=[*]
-    - deployments=[*]
-    - persistentvolumeclaims=[*]
+    - pods=[app.kubernetes.io/name,app.kubernetes.io/instance]
+    - deployments=[app.kubernetes.io/name,app.kubernetes.io/instance]
+    - statefulsets=[app.kubernetes.io/name,app.kubernetes.io/instance]
+    - cronjobs=[app.kubernetes.io/name,app.kubernetes.io/instance]
+    - namespaces=[kubernetes.io/metadata.name]
+    - persistentvolumeclaims=[excluded_from_alerts]
   prometheus:
     monitor:
       enabled: true


### PR DESCRIPTION
Replace per-resource [*] with explicit label allowlists to reduce
cardinality and make the contract explicit. Add statefulsets, cronjobs
and namespaces for parity. PVCs keep only excluded_from_alerts (used by
KubePersistentVolumeFillingUp alerts).
