### PR TITLE
feat(e2e-probes): Prometheus push A/B — shared Pushgateway + podinfo

### DIFF
--- a/kubernetes/apps/default/podinfo/test/cronjob.yaml
+++ b/kubernetes/apps/default/podinfo/test/cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           restartPolicy: Never
           initContainers:
             - name: load-tests
-              image: ghcr.io/oscaromeu/playwright-runner:1.57.0@sha256:bd04fbccbdb0be44f86b7ea9f1fae69fe0bb84050ea7cf0122a03c5a4cbce879
+              image: ghcr.io/oscaromeu/playwright-runner:1.57.0@sha256:fd630448b282cc174a6dd300ae0d63a48bdffb6bd00c0a02b505685de17a4fcd
               command: ["sh", "-c", "cp -rL /cm/* /tests/ && ls -la /tests"]
               volumeMounts:
                 - name: cm
@@ -32,7 +32,7 @@ spec:
                   mountPath: /tests
           containers:
             - name: playwright
-              image: ghcr.io/oscaromeu/playwright-runner:1.57.0@sha256:bd04fbccbdb0be44f86b7ea9f1fae69fe0bb84050ea7cf0122a03c5a4cbce879
+              image: ghcr.io/oscaromeu/playwright-runner:1.57.0@sha256:fd630448b282cc174a6dd300ae0d63a48bdffb6bd00c0a02b505685de17a4fcd
               imagePullPolicy: IfNotPresent
               # Run the probe, then upload the HTML report (video+trace embedded
               # on failure) to Garage under synthetics/<probe>/<timestamp>/report.
@@ -81,6 +81,11 @@ spec:
                   value: e2e
                 - name: CLICKHOUSE_USER
                   value: default
+                # A/B: the SAME run also pushes per-run gauges to Pushgateway
+                # (reporter-prometheus, gated by this var). Requires the rebuilt
+                # image that bakes the reporter — bump the digest above first.
+                - name: PUSHGATEWAY_URL
+                  value: http://pushgateway.observability.svc.cluster.local:9091
               volumeMounts:
                 - name: tests
                   mountPath: /tests

--- a/kubernetes/apps/observability/exporters/pushgateway/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/helmrelease.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pushgateway
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: pushgateway
+  values:
+    fullnameOverride: pushgateway
+
+    # honorLabels keeps the pushed job/env/run_id labels instead of letting the
+    # scrape overwrite them — mandatory for a Pushgateway, and what makes
+    # probe_success{job="podinfo",env="homelab"} work downstream.
+    serviceMonitor:
+      enabled: true
+      honorLabels: true
+
+    # Pushgateway is a stateless bridge; pushers re-push on the next run.
+    persistentVolume:
+      enabled: false
+
+    # Chart maps .securityContext → pod and .containerSecurityContext → container.
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      runAsGroup: 65534
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi

--- a/kubernetes/apps/observability/exporters/pushgateway/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/exporters/pushgateway/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: pushgateway
+spec:
+  interval: 15m
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-pushgateway
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 3.6.1

--- a/kubernetes/apps/observability/exporters/pushgateway/ks.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/ks.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pushgateway
+spec:
+  dependsOn:
+    - name: kube-prometheus-stack
+  targetNamespace: observability
+  path: ./kubernetes/apps/observability/exporters/pushgateway/app

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./namespace.yaml
   - ./alertmanager-webhook-logger/ks.yaml
   - ./ch-ui/ks.yaml
+  - ./exporters/pushgateway/ks.yaml
   - ./fastapi/ks.yaml
   - ./fluentbit/ks.yaml
   - ./gatus/ks.yaml


### PR DESCRIPTION
## What
- A shared Prometheus Pushgateway exporter (`observability/exporters/pushgateway`,
  prometheus-pushgateway chart via OCIRepository).
- The podinfo e2e probe now also pushes per-run gauges to it (reporter-prometheus,
  baked into the runner image) — the same run feeds both ClickHouse and Prometheus.

## Why
Empirical "event (ClickHouse) vs metric (Prometheus)" A/B on a real probe: show the
metrics-model limits — last-value (a dead cron stays green), a counter that can't
accumulate from a stateless job, and no per-run payload — next to the rich event store.

## Changes
- `observability/exporters/pushgateway/`: OCIRepository + HelmRelease (fullnameOverride
  pushgateway, serviceMonitor honorLabels, no persistence, hardened securityContext).
- `observability/kustomization.yaml`: register the exporter.
- `podinfo/test/cronjob.yaml`: bump the runner image to the digest that bakes
  reporter-prometheus, and set `PUSHGATEWAY_URL`.

## Test plan
- Pushgateway pod up; ServiceMonitor scraped by kube-prometheus-stack.
- After a probe run: `probe_success{job="podinfo",env="homelab"}` (and `probe_duration_ms`,
  `probe_runs_total`) visible in Prometheus.
- ClickHouse reporter and run-and-upload artifact upload unchanged (push is additive, env-gated).

## Related
- Runner image / reporter source: oscaromeu/containers (`reporter-prometheus.ts`).
- Grafana A/B dashboard: `grafana/e2e-ab.json` (containers repo).