### PR TITLE
feat(copyparty): add copyparty file server

### DIFF
--- a/kubernetes/apps/default/copyparty/app/helmrelease.yaml
+++ b/kubernetes/apps/default/copyparty/app/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: copyparty
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: copyparty
+  values:
+    controllers:
+      copyparty:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/9001/copyparty-ac
+              tag: 1.20.17@sha256:8906f3a4dbf745664634aea5d8a3fc2e5cc5a3d0d5edcf0a991dda613068d2aa
+            env:
+              TZ: ${TIMEZONE}
+              PRTY_NO_TLS: 1
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 44
+          - 65537
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        ports:
+          http:
+            port: &port 3923
+    route:
+      app:
+        hostnames: ["copyparty.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    configMaps:
+      config:
+        data:
+          copyparty.conf: |
+            [global]
+              hist: /hist
+
+            [/media]
+              /w/media
+              accs:
+                rw: *
+    persistence:
+      config:
+        type: configMap
+        name: copyparty
+        globalMounts:
+          - path: /cfg
+      hist:
+        type: emptyDir
+        globalMounts:
+          - path: /hist
+      media:
+        type: nfs
+        server: ${NAS_SERVER_IP}
+        path: ${NAS_SERVER_MEDIA_PATH}/Library
+        globalMounts:
+          - path: /w/media

--- a/kubernetes/apps/default/copyparty/app/kustomization.yaml
+++ b/kubernetes/apps/default/copyparty/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/copyparty/app/ocirepository.yaml
+++ b/kubernetes/apps/default/copyparty/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: copyparty
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/copyparty/ks.yaml
+++ b/kubernetes/apps/default/copyparty/ks.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app copyparty
+spec:
+  dependsOn:
+    - name: envoy-gateway
+      namespace: network
+  path: ./kubernetes/apps/default/copyparty/app
+  targetNamespace: default

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./namespace.yaml
   - ./actual/ks.yaml
   - ./atuin/ks.yaml
+  - ./copyparty/ks.yaml
   - ./docmost/ks.yaml
   - ./echo/ks.yaml
   - ./feishin/ks.yaml


### PR DESCRIPTION
## Description

Deploys [copyparty](https://github.com/9001/copyparty) (portable file server
with uploads, media indexing and thumbnails) in the `default` namespace.

- bjw-s `app-template` 5.0.1 via OCIRepository, image `ghcr.io/9001/copyparty-ac:1.20.17`
  (latest release, includes the dirkeys security fix)
- Exposed at `copyparty.${SECRET_DOMAIN}` through `envoy-internal` (TLS terminates
  at the gateway, `PRTY_NO_TLS=1`)
- Fully stateless — no PVC:
  - `copyparty.conf` lives in a ConfigMap mounted at `/cfg`
  - `.hist` cache (indexes, thumbnails, up2k dedup db) redirected to an emptyDir
    so it doesn't pollute the NFS share
- Media library mounted via NFS (`${NAS_SERVER_MEDIA_PATH}/Library` → `/w/media`),
  served at `/media` with anonymous read/write — same trust model as filebrowser
  on the same share
- Same NFS `supplementalGroups` (44, 65537) as filebrowser/jellyfin/kavita