### PR TITLE
feat(copyparty): add accounts, indexing, search and shares

### DIFF
--- a/kubernetes/apps/default/copyparty/app/helmrelease.yaml
+++ b/kubernetes/apps/default/copyparty/app/helmrelease.yaml
@@ -56,22 +56,36 @@ spec:
         data:
           copyparty.conf: |
             [global]
-              hist: /hist
+              e2dsa
+              e2ts
+              grid
+              hist: /state/hist
+              shr: /share
+              shr-db: /state/shares.db
+              shr-adm: oscar
 
             [/media]
               /w/media
               accs:
-                rw: *
+                r: *
+                A: oscar
     persistence:
       config:
         type: configMap
         name: copyparty
         globalMounts:
-          - path: /cfg
-      hist:
-        type: emptyDir
+          - path: /cfg/copyparty.conf
+            subPath: copyparty.conf
+      accounts:
+        type: secret
+        name: copyparty-secret
         globalMounts:
-          - path: /hist
+          - path: /cfg/accounts.conf
+            subPath: accounts.conf
+      state:
+        existingClaim: copyparty
+        globalMounts:
+          - path: /state
       media:
         type: nfs
         server: ${NAS_SERVER_IP}

--- a/kubernetes/apps/default/copyparty/app/kustomization.yaml
+++ b/kubernetes/apps/default/copyparty/app/kustomization.yaml
@@ -2,5 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./pvc.yaml
+  - ./secret.sops.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/default/copyparty/app/pvc.yaml
+++ b/kubernetes/apps/default/copyparty/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: copyparty
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: openebs-hostpath

--- a/kubernetes/apps/default/copyparty/app/secret.sops.yaml
+++ b/kubernetes/apps/default/copyparty/app/secret.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: copyparty-secret
+stringData:
+  accounts.conf: ENC[AES256_GCM,data:lEvYC0S9+PKv/mTRtmMQMCShLUyLxJkrKxg8Ssa9vIdHps0fQM571lvfOYWkkeybOqL9HUM=,iv:tN0NxIe/lo7bPnZQZ18fyn/Mw4ogGFuVzB9xvuUJaCA=,tag:v2gUdyT+skswEPhjybAM7A==,type:str]
+sops:
+  age:
+    - recipient: age1ptththqpxnx0zuzmq0peq9x30vqgdedjsdlsuzxr5gfc36mnwqlsylrpr8
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0ZjhNdmNndlc0Rzd6ZEkr
+        emlvRkZoTTlNMld4MGluMWhEZXpFWjdXdmlFCmJiU0JaVXlGK082ODRocGhkc3pF
+        YmZZRW1pV2xBUlFNenhJYWNWK3lza0UKLS0tIE1iaFVNOVEvL1VSNTArKy8xY1ZW
+        TW9HYXVmaUNvY2NwVUpsWjBBU2JDd1kKifytXJdPIRO5PKHNAwMSACzyKQBQGb4s
+        0XMOp3Ikx7nt3KS4pDKj10v/KUgPVV70VwGpTXUr/IReguRDtPc6NQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-08T19:59:20Z"
+  mac: ENC[AES256_GCM,data:wUMfDNd3IguAiWYUK/kHgARoqqVJ063s9O1CIkJ8ND6zksESilPsnzaIzfRndXDQGtvcuIbyMmF5CF53OkuIjv0ypjyTNVzNH1Kq+kD5HcllwKXID8gaQoIm+mZ7MV3dGcL+uADklafUUFx2rmSC4efWy33cSFoTTnXNrIPFBpA=,iv:aF0VfQZRqP+SsNR5cIGY9U7cL4DMDARkBpDCFDpf1as=,tag:kZWQ0Z8sku6fJc4duB2gBg==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.11.0


### PR DESCRIPTION
## Description

Extends the copyparty deployment with authentication and its main features:

- **Accounts**: anonymous access is now read-only; user `oscar` has full access
  (`A`). Password generated randomly and stored in a SOPS-encrypted Secret,
  mounted as an extra `accounts.conf` in `/cfg`
- **Indexing & search** (`e2dsa`, `e2ts`): search by name/size/date and audio
  tags (requires FFmpeg, included in the `-ac` image)
- **Shares** (`shr: /share`): temporary links with optional password/expiry,
  created by authenticated users; `oscar` is share admin
- **Grid view** by default
- **2Gi PVC at `/state`**: holds `shares.db` (real state — shared links must
  survive pod restarts) and the `hist` cache (expensive to rebuild: full NFS
  scan + tag parsing). Replaces the previous emptyDir