### PR TITLE
fix(copyparty): trust envoy proxy headers to pass cors-check

### DIFF
--- a/kubernetes/apps/default/copyparty/app/helmrelease.yaml
+++ b/kubernetes/apps/default/copyparty/app/helmrelease.yaml
@@ -63,6 +63,7 @@ spec:
               shr: /share
               shr-db: /state/shares.db
               shr-adm: oscar
+              xff-src: 10.42.0.0/16
 
             [/media]
               /w/media


### PR DESCRIPTION
## Description

Login (any POST) failed with `rejected by cors-check`: copyparty compares the
browser `Origin` (https) against its own scheme (plain http, TLS terminates at
Envoy). It would read `X-Forwarded-Proto` from Envoy, but `xff-src` defaults to
localhost-only, so proxy headers coming from the pod network were ignored.

Trust the cluster pod CIDR (`10.42.0.0/16`) so copyparty honors
`X-Forwarded-Proto` / `X-Forwarded-For` / `X-Forwarded-Host` from Envoy. This
also makes real client IPs show up in logs and the admin panel.