### PR TITLE
feat(copyparty): switch to dj image for bpm and key detection

### DIFF
--- a/kubernetes/apps/default/copyparty/app/helmrelease.yaml
+++ b/kubernetes/apps/default/copyparty/app/helmrelease.yaml
@@ -13,8 +13,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/9001/copyparty-ac
-              tag: 1.20.17@sha256:8906f3a4dbf745664634aea5d8a3fc2e5cc5a3d0d5edcf0a991dda613068d2aa
+              repository: ghcr.io/9001/copyparty-dj
+              tag: 1.20.17@sha256:36a897d21e57242232615211ad3c6aaecd6c7d6eccd1a432be1ad2b00c82a413
             env:
               TZ: ${TIMEZONE}
               PRTY_NO_TLS: 1
@@ -23,7 +23,7 @@ spec:
                 cpu: 10m
                 memory: 64Mi
               limits:
-                memory: 256Mi
+                memory: 512Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -65,6 +65,8 @@ spec:
               shr-db: /state/shares.db
               shr-adm: oscar
               xff-src: 10.42.0.0/16
+              mtp: .bpm=f,t30,/mtag/audio-bpm.py
+              mtp: key=f,t190,/mtag/audio-key.py
 
             [/media]
               /w/media


### PR DESCRIPTION
## Description

Enables music BPM and key detection, as seen in the copyparty demo:

- Switch image flavor `copyparty-ac` → `copyparty-dj`, which bundles `beatroot`
  and `keyfinder` for audio analysis
- Enable the `mtp` metadata parsers for `.bpm` and `key` tags (computed at
  index time; per-track timeouts of 30s/190s)
- Bump memory limit to 512Mi — analysis decodes each track with external
  processes

Already-indexed files may need a volume rescan (control panel) to pick up the
new tags.