### PR TITLE
feat(copyparty): one-shot tag-db rebuild to backfill bpm/key

### DIFF
--- a/kubernetes/apps/default/copyparty/app/helmrelease.yaml
+++ b/kubernetes/apps/default/copyparty/app/helmrelease.yaml
@@ -57,7 +57,8 @@ spec:
           copyparty.conf: |
             [global]
               e2dsa
-              e2ts
+              # TODO: revert to e2ts once the one-shot tag-db rebuild completes
+              e2tsr
               grid
               hist: /state/hist
               shr: /share


### PR DESCRIPTION
## Description

The BPM/key columns show no data for the existing library: mtp parsers only run
when a file gets indexed, and the library was indexed before the parsers were
added. Per copyparty docs, adding tags requires a one-shot `e2tsr` run to
rebuild the tag database.

Swap `e2ts` → `e2tsr` so the next boot wipes and rebuilds all tags, running the
BPM/key analysis over the whole library (slow: ~5-6 min of audio decoded twice
per track).

**Revert after the rebuild completes** — leaving `e2tsr` would repeat the full
rebuild on every pod restart. A TODO comment marks the spot.