### PR TITLE
chore(copyparty): incremental tag scans after backfill, real client ips

### DIFF
--- a/kubernetes/apps/default/copyparty/app/helmrelease.yaml
+++ b/kubernetes/apps/default/copyparty/app/helmrelease.yaml
@@ -57,14 +57,14 @@ spec:
           copyparty.conf: |
             [global]
               e2dsa
-              # TODO: revert to e2ts once the one-shot tag-db rebuild completes
-              e2tsr
+              e2ts
               grid
               hist: /state/hist
               shr: /share
               shr-db: /state/shares.db
               shr-adm: oscar
               xff-src: 10.42.0.0/16
+              rproxy: -1
               mtp: .bpm=f,t30,/mtag/audio-bpm.py
               mtp: key=f,t190,/mtag/audio-key.py
 


### PR DESCRIPTION
## Description

The one-shot `e2tsr` tag-db rebuild has completed — all 1660 audio files now
have BPM/key computed. Revert to incremental `e2ts` so pod restarts no longer
wipe and rebuild the tag database.

Also set `rproxy: -1` to resolve real client IPs from Envoy's
`X-Forwarded-For` (recommended by copyparty's own startup warning).