### PR TITLE
feat(syncthing): add syncthing file synchronization

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -25,5 +25,6 @@ resources:
   - ./pinchflat/ks.yaml
   - ./podinfo/ks.yaml
   - ./srs/ks.yaml
+  - ./syncthing/ks.yaml
   - ./twitch-radios/ks.yaml
   - ./vikunja/ks.yaml

--- a/kubernetes/apps/default/syncthing/app/helmrelease.yaml
+++ b/kubernetes/apps/default/syncthing/app/helmrelease.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: syncthing
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: syncthing
+  values:
+    controllers:
+      syncthing:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/syncthing/syncthing
+              tag: 2.1.2@sha256:4464f4161dd0251e20d46bb3aec83363db75d80cef1abdd5d5fd4054b04a004d
+            env:
+              TZ: ${TIMEZONE}
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /rest/noauth/health
+                    port: &port 8384
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 100Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: syncthing
+        ports:
+          http:
+            port: *port
+      sync:
+        controller: syncthing
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: ${SYNCTHING_LB}
+        ports:
+          discovery:
+            port: 21027
+            protocol: UDP
+          listen-tcp:
+            port: 22000
+            protocol: TCP
+          listen-udp:
+            port: 22000
+            protocol: UDP
+    route:
+      app:
+        hostnames: ["sync.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      data:
+        existingClaim: syncthing
+        globalMounts:
+          - path: /var/syncthing

--- a/kubernetes/apps/default/syncthing/app/kustomization.yaml
+++ b/kubernetes/apps/default/syncthing/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/syncthing/app/ocirepository.yaml
+++ b/kubernetes/apps/default/syncthing/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: syncthing
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/syncthing/app/pvc.yaml
+++ b/kubernetes/apps/default/syncthing/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: syncthing
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: openebs-hostpath

--- a/kubernetes/apps/default/syncthing/ks.yaml
+++ b/kubernetes/apps/default/syncthing/ks.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app syncthing
+spec:
+  dependsOn:
+    - name: envoy-gateway
+      namespace: network
+  path: ./kubernetes/apps/default/syncthing/app
+  targetNamespace: default

--- a/kubernetes/components/sops/cluster-secrets.sops.yaml
+++ b/kubernetes/components/sops/cluster-secrets.sops.yaml
@@ -13,7 +13,7 @@ stringData:
     #ENC[AES256_GCM,data:P7Q+/qEhfg==,iv:JknGADonYRvoykdpxeT7Fw8mY/bD2XMToktBK9DCnGQ=,tag:eOlRkqys8h/wJY+yj+AmDw==,type:comment]
     SMTP_RELAY_LB: ENC[AES256_GCM,data:ye7gAn+NEMVUUDw=,iv:+U4TNcuSRf7XVTBjpJ8D20J/Q2hM/hR+zKER2/EP9Hs=,tag:tHk6M2/NDIuTQaEFD/DpKQ==,type:str]
     CRUNCHY_LB_POSTGRES: ENC[AES256_GCM,data:as5FFJArkZL3kYo=,iv:Tu0LYLrLoUxR9s8zTvXbdiuJ89mDTwy5pxXSvxIiYI0=,tag:ksokXOCSdw7Z+P2dRFIhUw==,type:str]
-    PLEX_LB: ENC[AES256_GCM,data:ZjiNaho2+pa78xk=,iv:Ygj4ojtlrD4YP22o7T5WreZuSLf5sjzEt9s2TyODXtE=,tag:0x86cQ4JAWBxS2Fp1wbydw==,type:str]
+    SYNCTHING_LB: ENC[AES256_GCM,data:2BU3p9zeca4CO2Y=,iv:ool402axVL3usdI5Ow3+8jdYhpxZzsNUt3fyFLYW4yo=,tag:fg1GPH19dGNluykfuxNmVA==,type:str]
     JELLYFIN_LB: ENC[AES256_GCM,data:z549kgw1U5Qw4z4=,iv:7xLmmNDkh/Ty9yaL5AGMXfskXNxuQLxDmUlAkcMEOoU=,tag:x0EOgYL/FFaA+5+OUFIdbA==,type:str]
     #ENC[AES256_GCM,data:JIOV0kM=,iv:sY9CdUtHbtiEF0egzHNKE72bz0Ek1Z3dYWelC0UsjCk=,tag:URJo2VL71AFg4oYawUyByQ==,type:comment]
     SECRET_LDAP_USER: ENC[AES256_GCM,data:m/lenu6RIU+c6M3z,iv:sjBs0mUtAVnX5xnsrqSNVhIxQOqB7Ltxq0Ls8R/kXSQ=,tag:nnhOauNmgrRnH5IP1pfhCA==,type:str]
@@ -31,8 +31,8 @@ sops:
             ZU5CNEVTaksvRlNNa0w0UzNrNU1pMU0K6ZRHeXoaXbvtBNfolQ3Korf33LwQxqq0
             JKr6WbcFUk9g9Noxai+j+xxX4XJ7/r23osfEp4uVXRe1bOSXdpP+bg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-13T18:03:01Z"
-    mac: ENC[AES256_GCM,data:E8xR+vl92e3oDF36OzVh9DBOmIBDTzzpn6IPjO+4Irb7a593/4gTunOOEbizkpUJsYZmjz+D5BSLGy72pjhwQCBgQ/qTJZvMoOr8Stn7viV7zL4mtshkpv/JV/Q+pFtznqgs2DsFsZW51B6CaWH5CBbGY7iACmqrl/Hkv5CwpAA=,iv:X0XvwRVxGOPJcr7nVrcl7/L35nJKlaZBa0pTRbodWQk=,tag:XOIaW34sxoUNJQR++Hvnhg==,type:str]
+    lastmodified: "2026-07-09T05:20:27Z"
+    mac: ENC[AES256_GCM,data:FyQTMw0mad4h5qWJoFh3oQ+lnq8gFLnCPTI0ahN93KN2xzLmtfjgvDv6l2NjsLQ+qjUKcJt5t1Waw1BENSyudbh7RjWoxA2J69tKjx5oSSGHzetPqWlg9z9l6oPtEMyW+dcycIXykxO1kfZDL5vW1yYMLmEPwBbl9d7VN7X9Gic=,iv:baOiXdcok7tOzYk3fvL2yPqWQ6k6Oe5KGZprArjKrbY=,tag:1Jgc9yzE2rqBasWcCL8RfA==,type:str]
     encrypted_regex: ^(data|stringData)$
     mac_only_encrypted: true
     version: 3.11.0


### PR DESCRIPTION
## Description

Deploys [syncthing](https://github.com/syncthing/syncthing) v2.1.2 in the
`default` namespace.

- Web UI at `sync.${SECRET_DOMAIN}` through `envoy-internal`
- Dedicated LoadBalancer service (`${SYNCTHING_LB}`) for the sync protocol:
  22000/tcp+udp (transfers) and 21027/udp (local discovery)
- 5Gi PVC at `/var/syncthing` (device keys, config, indexes)
- Hardened securityContext + health probes on `/rest/noauth/health`
- Adds `SYNCTHING_LB` to `cluster-secrets`