### PR TITLE
fix(syncthing): local pvc for db, narrow nfs mounts for synced folders

### DIFF
--- a/kubernetes/apps/default/syncthing/app/helmrelease.yaml
+++ b/kubernetes/apps/default/syncthing/app/helmrelease.yaml
@@ -47,6 +47,9 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 44
+          - 65537
         seccompProfile: { type: RuntimeDefault }
     service:
       app:
@@ -82,8 +85,18 @@ spec:
                 port: *port
     persistence:
       data:
-        type: nfs
-        server: ${NAS_SERVER_IP}
-        path: ${NAS_SERVER_MEDIA_PATH}/Library
+        existingClaim: syncthing
         globalMounts:
           - path: /var/syncthing
+      practice:
+        type: nfs
+        server: ${NAS_SERVER_IP}
+        path: ${NAS_SERVER_MEDIA_PATH}/Library/Media/Videos/Practice
+        globalMounts:
+          - path: /var/syncthing/Practice
+      music:
+        type: nfs
+        server: ${NAS_SERVER_IP}
+        path: ${NAS_SERVER_MEDIA_PATH}/Library/Media/Music
+        globalMounts:
+          - path: /var/syncthing/Music


### PR DESCRIPTION
## Description

Syncthing's home (`/var/syncthing`) holds its config, device keys and SQLite
index database — none of which should live on NFS (unreliable locking →
database corruption, plus it litters the media share root with config files).

- Home back on the local `syncthing` PVC
- Two narrow NFS mounts for the actual sync targets:
  `Library/Media/Videos/Practice` → `/var/syncthing/Practice` and
  `Library/Media/Music` → `/var/syncthing/Music`
- `supplementalGroups` (44, 65537) for NAS write access, matching the other
  NFS-mounting apps