### PR TITLE
revert(dragonfly): roll back dragonfly to v1.22.0 (phase 2 rollback)

### DIFF
--- a/kubernetes/apps/databases/dragonfly/app/dragonfly.yaml
+++ b/kubernetes/apps/databases/dragonfly/app/dragonfly.yaml
@@ -21,7 +21,7 @@ spec:
         resourceFieldRef:
           divisor: 1Mi
           resource: limits.memory
-  image: ghcr.io/dragonflydb/dragonfly:v1.39.0
+  image: ghcr.io/dragonflydb/dragonfly:v1.22.0
   replicas: 2
   resources:
     limits:


### PR DESCRIPTION
Runbook drill: phase-2 rollback. Reverts the v1.39.0 image bump; restore of the pre-upgrade snapshots follows per runbook.