### PR TITLE
feat(observability): archive alert history in ClickHouse

### DIFF
--- a/kubernetes/apps/observability/alert-history/README.md
+++ b/kubernetes/apps/observability/alert-history/README.md
@@ -1,0 +1,130 @@
+# alert-history
+
+Long-term archive of every Alertmanager notification, in ClickHouse.
+
+Alertmanager is stateless by design: it knows which alerts are firing *now* and
+nothing about last quarter. This app keeps the history so questions like "which
+alert wakes me up most and never means anything?" can be answered with data
+instead of memory.
+
+## Path
+
+```
+alertmanager  ──webhook──→  fluent-bit aggregator (in_http :8888)
+                            observability/fluentbit/aggregator/pipelines/alertmanager.yaml
+                   ──http──→  clickhouse  observability.alerts_raw     one row per webhook
+                   ────MV───→  clickhouse  observability.alert_events  one row per alert
+```
+
+One webhook carries an `alerts[]` array of N alerts. Fluent Bit cannot split one
+record into many, so it does not try: the body is stored verbatim with
+`FORMAT JSONAsString` and the materialized view does the `arrayJoin`. ClickHouse
+is the transform engine, which is why no Vector deployment or Lua filter exists
+here.
+
+`alerts_raw` is kept for a year on purpose. If `alert_events` needs a new column
+later, it can be backfilled by replaying the raw payloads rather than being
+lost.
+
+The `ch-archive` receiver is `continue: true` in the Alertmanager route, so this
+archive runs alongside Pushover and the VictoriaLogs archive without swallowing
+notifications.
+
+## Schema
+
+[`app/schema.sql`](app/schema.sql). Applied by a Job; every statement is
+`IF NOT EXISTS`, so it is safe to re-run. The parent Flux Kustomization sets
+`force: true` because Job specs are immutable — editing `schema.sql` rolls the
+ConfigMap hash and Flux recreates the Job.
+
+One detail worth not re-learning the hard way: Alertmanager sends
+`endsAt: 0001-01-01T00:00:00Z` while an alert is still firing. That is below the
+`DateTime64` range and the parser **saturates it to 1900-01-01 rather than
+returning NULL**, so the sentinel is caught on the raw string before parsing.
+Miss this and every duration computed against a firing alert is garbage.
+
+## Dashboard queries
+
+The Grafana dashboard sidecar is disabled in this cluster (`allowUiUpdates:
+true`), so dashboards are built in the UI. Use the `ClickHouse` datasource.
+
+**Noise ranking — the tuning worklist**
+
+```sql
+SELECT alertname,
+       countIf(status = 'firing') AS fires,
+       uniq(fingerprint)          AS instances
+FROM observability.alert_events
+WHERE $__timeFilter(starts_at)
+GROUP BY alertname
+ORDER BY fires DESC
+LIMIT 20
+```
+
+**MTTR distribution by severity** — look at p95, not the average
+
+```sql
+SELECT severity,
+       count()                                                  AS resolved,
+       avg(dateDiff('second', starts_at, ends_at))              AS mttr_avg_s,
+       quantile(0.95)(dateDiff('second', starts_at, ends_at))   AS mttr_p95_s
+FROM observability.alert_events
+WHERE status = 'resolved' AND ends_at IS NOT NULL
+  AND $__timeFilter(starts_at)
+GROUP BY severity
+ORDER BY resolved DESC
+```
+
+**Flapping — cycles shorter than five minutes**
+
+```sql
+SELECT alertname,
+       countIf(dateDiff('second', starts_at, ends_at) < 300) AS short_cycles,
+       count()                                               AS total
+FROM observability.alert_events
+WHERE status = 'resolved' AND ends_at IS NOT NULL
+  AND $__timeFilter(starts_at)
+GROUP BY alertname
+HAVING short_cycles > 0
+ORDER BY short_cycles DESC
+```
+
+Usually means a threshold is wrong or `for:` is too short.
+
+**Out-of-hours load — what actually costs sleep**
+
+```sql
+SELECT toHour(starts_at) AS hour,
+       countIf(severity = 'critical') AS critical,
+       count()                        AS total
+FROM observability.alert_events
+WHERE status = 'firing' AND $__timeFilter(starts_at)
+GROUP BY hour
+ORDER BY hour
+```
+
+**Currently firing, oldest first**
+
+```sql
+SELECT alertname, namespace, service, severity, starts_at, summary
+FROM observability.alert_events
+WHERE ends_at IS NULL
+ORDER BY starts_at
+```
+
+**Filtering on an arbitrary label** — no schema change needed
+
+```sql
+SELECT * FROM observability.alert_events
+WHERE labels['pod'] LIKE 'jellyfin-%'
+```
+
+## Verified
+
+Schema, fan-out and the `endsAt` sentinel were tested against
+`clickhouse-server:26.3` with a real two-alert webhook payload (one firing, one
+resolved): 1 raw row produced 2 `alert_events` rows, labels and annotations
+landed as `Map`, and re-applying `schema.sql` was a no-op.
+
+Not yet verified on-cluster: the Job's ClickHouse connection and the Alertmanager
+→ Fluent Bit hop. See the checks in the PR description.

--- a/kubernetes/apps/observability/alert-history/app/job.yaml
+++ b/kubernetes/apps/observability/alert-history/app/job.yaml
@@ -1,0 +1,49 @@
+---
+# Applies the alert-history schema to ClickHouse. Every statement is
+# IF NOT EXISTS, so re-running is a no-op.
+#
+# The Job name is fixed and Job specs are immutable, so the parent Flux
+# Kustomization sets `force: true` — editing schema.sql rolls the ConfigMap
+# hash, Flux recreates the Job, and the new DDL is applied.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: alert-history-schema
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: schema
+          image: docker.io/clickhouse/clickhouse-server:26.3
+          command:
+            - clickhouse-client
+            - --host=clickhouse-clickhouse-headless.databases.svc.cluster.local
+            - --port=9000
+            - --user=default
+            - --multiquery
+            - --queries-file=/schema/schema.sql
+          volumeMounts:
+            - name: schema
+              mountPath: /schema
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+      volumes:
+        - name: schema
+          configMap:
+            name: alert-history-schema

--- a/kubernetes/apps/observability/alert-history/app/kustomization.yaml
+++ b/kubernetes/apps/observability/alert-history/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./job.yaml
+
+configMapGenerator:
+  - name: alert-history-schema
+    files:
+      - schema.sql=./schema.sql
+
+# Hash suffix is intentional here (unlike the fluentbit pipelines): it is what
+# makes a schema.sql edit produce a new Job spec for Flux to force-recreate.
+generatorOptions:
+  disableNameSuffixHash: false

--- a/kubernetes/apps/observability/alert-history/app/schema.sql
+++ b/kubernetes/apps/observability/alert-history/app/schema.sql
@@ -1,0 +1,98 @@
+-- Alert history: long-term archive of every Alertmanager notification.
+--
+-- Ingest path:
+--   alertmanager --webhook--> fluent-bit aggregator (in_http :8888)
+--                --http-----> clickhouse  observability.alerts_raw   (one row per webhook)
+--                --MV-------> clickhouse  observability.alert_events (one row per alert)
+--
+-- alerts_raw keeps the untouched payload on purpose: if alert_events ever needs
+-- a new column, it can be backfilled by replaying this table instead of being
+-- lost. Cheap to keep — a few thousand rows a month.
+
+CREATE DATABASE IF NOT EXISTS observability;
+
+-- ---------------------------------------------------------------------------
+-- Raw landing table. Written with FORMAT JSONAsString, so the whole webhook
+-- body lands in a single column and no parsing happens at ingest time.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS observability.alerts_raw
+(
+    payload     String,
+    received_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(received_at)
+ORDER BY received_at
+TTL toDateTime(received_at) + INTERVAL 1 YEAR;
+
+-- ---------------------------------------------------------------------------
+-- Query table. One row per alert per state change (firing / resolved).
+--
+-- ORDER BY leads with alertname because every analytical query filters or
+-- groups by it; fingerprint then groups the lifecycle of a single alert
+-- instance together on disk.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS observability.alert_events
+(
+    received_at   DateTime64(3),
+    status        LowCardinality(String),          -- firing | resolved
+    alertname     LowCardinality(String),
+    severity      LowCardinality(String),
+    namespace     LowCardinality(String),
+    service       LowCardinality(String),
+    instance      String,
+    fingerprint   String,                          -- stable id of the alert instance
+    starts_at     DateTime64(3),
+    ends_at       Nullable(DateTime64(3)),         -- NULL while firing
+    generator_url String,
+    summary       String,
+    description   String,
+    runbook_url   String,
+    labels        Map(LowCardinality(String), String),
+    annotations   Map(LowCardinality(String), String),
+    receiver      LowCardinality(String),
+    group_key     String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(starts_at)
+ORDER BY (alertname, fingerprint, starts_at)
+TTL toDateTime(starts_at) + INTERVAL 3 YEAR;
+
+-- ---------------------------------------------------------------------------
+-- Fan-out: one webhook carries an alerts[] array of N alerts. arrayJoin turns
+-- it into N rows. This is the step Fluent Bit cannot do on its own, and the
+-- reason no Vector/Lua transform is needed.
+-- ---------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS observability.alert_events_mv
+TO observability.alert_events
+AS
+SELECT
+    received_at,
+    JSONExtractString(alert, 'status')                                AS status,
+    JSONExtractString(alert, 'labels', 'alertname')                   AS alertname,
+    JSONExtractString(alert, 'labels', 'severity')                    AS severity,
+    JSONExtractString(alert, 'labels', 'namespace')                   AS namespace,
+    JSONExtractString(alert, 'labels', 'service')                     AS service,
+    JSONExtractString(alert, 'labels', 'instance')                    AS instance,
+    JSONExtractString(alert, 'fingerprint')                           AS fingerprint,
+    parseDateTime64BestEffortOrNull(JSONExtractString(alert, 'startsAt'), 3) AS starts_at,
+    -- Alertmanager sends 0001-01-01T00:00:00Z while an alert is still firing.
+    -- That is below the DateTime64 range, and the parser SATURATES it to
+    -- 1900-01-01 instead of returning NULL — so the sentinel has to be caught
+    -- on the raw string, before parsing. Getting this wrong makes every
+    -- duration computed against a firing alert nonsense.
+    if(
+        startsWith(JSONExtractString(alert, 'endsAt'), '0001-01-01'),
+        NULL,
+        parseDateTime64BestEffortOrNull(JSONExtractString(alert, 'endsAt'), 3)
+    )                                                                 AS ends_at,
+    JSONExtractString(alert, 'generatorURL')                          AS generator_url,
+    JSONExtractString(alert, 'annotations', 'summary')                AS summary,
+    JSONExtractString(alert, 'annotations', 'description')            AS description,
+    JSONExtractString(alert, 'annotations', 'runbook_url')            AS runbook_url,
+    JSONExtract(alert, 'labels', 'Map(String, String)')               AS labels,
+    JSONExtract(alert, 'annotations', 'Map(String, String)')          AS annotations,
+    JSONExtractString(payload, 'receiver')                            AS receiver,
+    JSONExtractString(payload, 'groupKey')                            AS group_key
+FROM observability.alerts_raw
+ARRAY JOIN JSONExtractArrayRaw(payload, 'alerts') AS alert;

--- a/kubernetes/apps/observability/alert-history/ks.yaml
+++ b/kubernetes/apps/observability/alert-history/ks.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: alert-history
+spec:
+  targetNamespace: observability
+  path: ./kubernetes/apps/observability/alert-history/app
+  dependsOn:
+    - name: clickhouse-cluster
+  # Job specs are immutable; force lets a schema.sql change recreate the Job.
+  force: true

--- a/kubernetes/apps/observability/fluentbit/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/fluentbit/aggregator/helmrelease.yaml
@@ -28,6 +28,12 @@ spec:
     serviceMonitor:
       enabled: true
     logLevel: warn
+    # Alertmanager webhook receiver (pipelines/alertmanager.yaml)
+    extraPorts:
+      - name: alertmanager
+        port: 8888
+        containerPort: 8888
+        protocol: TCP
     extraVolumes:
       - name: parsers
         configMap:

--- a/kubernetes/apps/observability/fluentbit/aggregator/pipelines/alertmanager.yaml
+++ b/kubernetes/apps/observability/fluentbit/aggregator/pipelines/alertmanager.yaml
@@ -1,0 +1,27 @@
+pipeline:
+  inputs:
+    # Receives Alertmanager webhook notifications. Reachable in-cluster as
+    # http://fluent-bit-aggregator.observability.svc.cluster.local:8888/
+    # (port exposed via extraPorts in the aggregator HelmRelease).
+    - name: http
+      tag: alertmanager
+      listen: 0.0.0.0
+      port: 8888
+      # One webhook body = one record. The alerts[] fan-out happens in
+      # ClickHouse (alert_events_mv), not here.
+      successful_response_code: 200
+
+  outputs:
+    # ClickHouse HTTP interface. JSONAsString stores the whole webhook body in
+    # observability.alerts_raw.payload; received_at comes from the column
+    # DEFAULT. A materialized view explodes alerts[] into alert_events.
+    - name: http
+      match: alertmanager
+      host: clickhouse-clickhouse-headless.databases.svc.cluster.local
+      port: 8123
+      uri: /?query=INSERT+INTO+observability.alerts_raw+(payload)+FORMAT+JSONAsString
+      format: json_lines
+      json_date_format: iso8601
+      # No gzip: payloads are a few KB and ClickHouse needs the body verbatim.
+      log_response_payload: true
+      retry_limit: 5

--- a/kubernetes/apps/observability/fluentbit/aggregator/pipelines/kustomization.yaml
+++ b/kubernetes/apps/observability/fluentbit/aggregator/pipelines/kustomization.yaml
@@ -7,6 +7,7 @@ configMapGenerator:
   - name: pipelines-aggregator
     files:
       - kubernetes-events.yaml=./kubernetes-events.yaml
+      - alertmanager.yaml=./alertmanager.yaml
       #- syslog.yaml=./syslog.yaml
       #- kafka.yaml=./kafka.yaml
 generatorOptions:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/config-alertmanager.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/config-alertmanager.yaml
@@ -16,6 +16,8 @@ spec:
             matchType: =
       - receiver: vl-archive
         continue: true
+      - receiver: ch-archive
+        continue: true
       - receiver: pushover
         matchers:
           - name: severity
@@ -46,6 +48,11 @@ spec:
     - name: vl-archive
       webhookConfigs:
         - url: http://alertmanager-webhook-logger.observability.svc.cluster.local:6725/
+          sendResolved: true
+    # Long-term alert history in ClickHouse (observability.alert_events).
+    - name: ch-archive
+      webhookConfigs:
+        - url: http://fluent-bit-aggregator.observability.svc.cluster.local:8888/
           sendResolved: true
     - name: pushover
       pushoverConfigs:

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./alert-history/ks.yaml
   - ./alertmanager-webhook-logger/ks.yaml
   - ./ch-ui/ks.yaml
   - ./exporters/pushgateway/ks.yaml


### PR DESCRIPTION
## Why

Alertmanager is stateless by design: it knows what is firing right now and nothing about last quarter. There is currently no way to answer "which alert fires most and never means anything?", "what is the real MTTR?", or "which alerts flap?" without scraping notification history by hand.

This adds a long-term archive of every Alertmanager notification to the ClickHouse instance that is already deployed.

## How

```
alertmanager  --webhook-->  fluent-bit aggregator (in_http :8888)
                 --http--->  observability.alerts_raw     one row per webhook
                 ---MV---->  observability.alert_events   one row per alert
```

A webhook carries an `alerts[]` array of N alerts, and Fluent Bit cannot split one record into many. Instead of adding a Vector deployment or a Lua filter, the body is stored verbatim with `FORMAT JSONAsString` and a materialized view does the `arrayJoin` — ClickHouse is the transform engine.

Keeping `alerts_raw` (1y TTL) means `alert_events` can gain columns later and be backfilled by replaying the payloads, instead of the unmapped fields being lost.

No new components: the aggregator, ClickHouse, ch-ui and the Grafana datasource all already exist.

## Changes

- `alert-history/` — schema (`alerts_raw`, `alert_events`, MV) applied by an idempotent Job. Parent Kustomization sets `force: true` since Job specs are immutable.
- `fluentbit/aggregator/pipelines/alertmanager.yaml` — `in_http` receiver on :8888, HTTP output to ClickHouse.
- `fluentbit/aggregator/helmrelease.yaml` — expose port 8888 via `extraPorts`.
- `kube-prometheus-stack/app/config-alertmanager.yaml` — new `ch-archive` receiver with `continue: true`, so Pushover and the VictoriaLogs archive are unaffected.

## Gotcha worth not re-learning

Alertmanager sends `endsAt: 0001-01-01T00:00:00Z` while an alert is still firing. That is below the `DateTime64` range and `parseDateTime64BestEffortOrNull` **saturates it to 1900-01-01 rather than returning NULL**. Left unhandled, every duration computed against a firing alert is garbage. The sentinel is caught on the raw string before parsing.

## Testing

Verified locally against `clickhouse-server:26.3` with a realistic two-alert webhook payload (one firing, one resolved):

- 1 row in `alerts_raw` produced 2 rows in `alert_events` — fan-out works
- labels and annotations landed as `Map(String, String)`
- `ends_at` is NULL for the firing alert and the real timestamp for the resolved one
- re-applying `schema.sql` is a no-op
- noise-ranking / MTTR / currently-firing queries all return correct results
- `extraPorts` shape checked against the fluent-bit chart 0.55.0 values

## Post-merge checks

Not verifiable off-cluster:

1. The schema Job connects to `clickhouse-clickhouse-headless.databases:9000` as `default` with no password (the e2e cronjob already uses that path over HTTP).
2. Alertmanager reaches the aggregator on :8888.

After the first `groupInterval` (5m), confirm in ch-ui:

```sql
SELECT count() FROM observability.alerts_raw;
SELECT count() FROM observability.alert_events;
```

## Follow-ups

- Build the Grafana panels from the queries in the README (the dashboard sidecar is disabled in this cluster, so dashboards are UI-managed).
- Consider retiring `alertmanager-webhook-logger` once this has proven itself.
- ClickHouse is capped at 2Gi memory / 10Gi disk. Fine for alert history (thousands of rows a month), but that limit is the first thing to revisit before pointing kube events or logs at it.
