### PR TITLE
feat: stop echo-server

### DIFF
--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       echo:
+        replicas: 0
         strategy: RollingUpdate
         containers:
           app:

--- a/kubernetes/apps/default/echo/test/cronjob.yaml
+++ b/kubernetes/apps/default/echo/test/cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: echo-test
 spec:
+  suspend: true
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
Stops echo-server without deleting anything:

- `replicas: 0` on the echo controller in the HelmRelease — pods are stopped, but the HelmRelease, Service, HTTPRoute and ServiceMonitor stay in place.
- `suspend: true` on the `echo-test` CronJob so the Playwright probe doesn't fail every 5 minutes against the stopped service.

To bring it back, revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)