### PR TITLE
fix: alertmanager pushover notifications

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/config-alertmanager.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/config-alertmanager.yaml
@@ -14,8 +14,6 @@ spec:
           - name: alertname
             value: InfoInhibitor
             matchType: =
-      - receiver: vl-archive
-        continue: true
       - receiver: ch-archive
         continue: true
       - receiver: pushover
@@ -23,12 +21,11 @@ spec:
           - name: severity
             value: critical
             matchType: =
+    # "..." disables grouping: one notification per alert.
     groupBy:
-      - alertname
-      - cluster
-      - job
+      - "..."
     groupInterval: 5m
-    groupWait: 1m
+    groupWait: 30s
 
   inhibitRules:
     - equal:
@@ -45,10 +42,6 @@ spec:
 
   receivers:
     - name: blackhole
-    - name: vl-archive
-      webhookConfigs:
-        - url: http://alertmanager-webhook-logger.observability.svc.cluster.local:6725/
-          sendResolved: true
     # Long-term alert history in ClickHouse (observability.alert_events).
     - name: ch-archive
       webhookConfigs:
@@ -81,8 +74,7 @@ spec:
           sendResolved: true
           sound: gamelan
           title: >-
-            [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
-          ttl: 86400s
+            [{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}
           token:
             name: alertmanager-secret
             key: ALERTMANAGER_PUSHOVER_TOKEN


### PR DESCRIPTION
Some Pushover notifications were seemingly going missing. Two causes in the alertmanager config: grouped alerts get concatenated into a single message (and truncated at Pushover's 1024 char limit), and the 24h TTL makes delivered messages delete themselves from the device after a day, which looks like they never arrived.

This disables grouping entirely (`group_by: ['...']`) so every alert arrives as its own notification, drops the TTL so messages stay until dismissed, and lowers group_wait to 30s since there's nothing left to batch. Only critical alerts keep paging, same as before; warnings stay in the ClickHouse archive.

Also removes the vl-archive receiver, which was still pointing at the alertmanager-webhook-logger service removed in 58fc1de.