### PR TITLE
fix(victoria-logs): move route to internal gateway

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
         hostnames:
           - victoria-logs.${SECRET_DOMAIN}
         parentRefs:
-          - name: envoy-external
+          - name: envoy-internal
             namespace: network
         extraRules:
           - filters:


### PR DESCRIPTION
## What
Moves the victoria-logs HTTPRoute from envoy-external to envoy-internal.

## Why
The LogsQL query API was reachable from the public internet through the Cloudflare tunnel with no authentication - full cluster logs readable by anyone knowing the hostname (verified with curl against the public path). VMUI keeps working from LAN/Tailscale via the internal gateway; external-dns should drop the public record on reconcile.

## Test plan
- [x] dig victoria-logs.oscaromeu.io @1.1.1.1 stops resolving
- [x] curl via the Cloudflare edge fails
- [x] LogsQL queries from LAN keep working