### PR TITLE
feat(observability): buffer fluentbit chunks on disk with checkpoints

### DIFF
--- a/kubernetes/apps/observability/fluentbit/_shared/fluentbit.yaml
+++ b/kubernetes/apps/observability/fluentbit/_shared/fluentbit.yaml
@@ -11,12 +11,11 @@ service:
   http_port: 2020
   health_check: true
   # https://docs.fluentbit.io/manual/administration/buffering-and-storage#fluent-bit.yaml
-  mem_buf_limit: 50MB # 300MB - 1GB
   storage.path: /var/log/fluentbit/storage
   storage.sync: full
   storage.checksum: true
   storage.max_chunks_up: 128 # 512
-  storage.backlog.mem_limit: 5M # 200M - 500M
+  storage.backlog.mem_limit: 64M
   storage.backlog.flush_on_shutdown: true
   storage.metrics: true
   storage.delete_irrecoverable_chunks: true

--- a/kubernetes/apps/observability/fluentbit/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/fluentbit/aggregator/helmrelease.yaml
@@ -28,6 +28,14 @@ spec:
     serviceMonitor:
       enabled: true
     logLevel: warn
+    updateStrategy:
+      type: Recreate
+    resources:
+      requests:
+        cpu: 25m
+        memory: 96Mi
+      limits:
+        memory: 384Mi
     # Alertmanager webhook receiver (pipelines/alertmanager.yaml)
     extraPorts:
       - name: alertmanager
@@ -35,6 +43,9 @@ spec:
         containerPort: 8888
         protocol: TCP
     extraVolumes:
+      - name: storage
+        persistentVolumeClaim:
+          claimName: fluent-bit-aggregator-storage
       - name: parsers
         configMap:
           defaultMode: 420
@@ -50,6 +61,8 @@ spec:
       #    secretName: topic-cluster-apps-logs-certs
       #    defaultMode: 420
     extraVolumeMounts:
+      - name: storage
+        mountPath: /var/log/fluentbit/storage
       - name: parsers
         mountPath: /fluent-bit/etc/conf/parsers.d/
       - name: pipelines-aggregator

--- a/kubernetes/apps/observability/fluentbit/aggregator/kustomization.yaml
+++ b/kubernetes/apps/observability/fluentbit/aggregator/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./pipelines
+  - ./pvc.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/observability/fluentbit/aggregator/pipelines/alertmanager.yaml
+++ b/kubernetes/apps/observability/fluentbit/aggregator/pipelines/alertmanager.yaml
@@ -7,6 +7,7 @@ pipeline:
       tag: alertmanager
       listen: 0.0.0.0
       port: 8888
+      storage.type: filesystem
       # One webhook body = one record. The alerts[] fan-out happens in
       # ClickHouse (alert_events_mv), not here.
       successful_response_code: 200
@@ -25,3 +26,4 @@ pipeline:
       # No gzip: payloads are a few KB and ClickHouse needs the body verbatim.
       log_response_payload: true
       retry_limit: 5
+      storage.total_limit_size: 64M

--- a/kubernetes/apps/observability/fluentbit/aggregator/pipelines/kubernetes-events.yaml
+++ b/kubernetes/apps/observability/fluentbit/aggregator/pipelines/kubernetes-events.yaml
@@ -7,6 +7,8 @@ pipeline:
       kube_url: https://kubernetes.default.svc
       # checkpoint so a restart does not re-ingest the whole backlog
       db: /var/log/fluentbit/storage/k8s-events.db
+      db.sync: normal
+      storage.type: filesystem
       interval_sec: 5
 
   filters:
@@ -31,13 +33,28 @@ pipeline:
       rename: obj_name k_object_name
       add: stream k8s_events
 
+    - name: record_modifier
+      match: k8s_events
+      remove_key:
+        - meta_managedFields
+        - meta_resourceVersion
+        - meta_uid
+        - meta_creationTimestamp
+        - meta_selfLink
+        - obj_uid
+        - obj_resourceVersion
+        - obj_apiVersion
+        - apiVersion
+        - kind
+
   outputs:
     - name: http
       match: k8s_events
       host: victoria-logs-server.observability.svc.cluster.local
       port: 9428
-      uri: /insert/jsonline?_stream_fields=stream,k_namespace_name,type,reason&_msg_field=message&_time_field=lastTimestamp
+      uri: /insert/jsonline?_stream_fields=stream,k_namespace_name,type,reason&_msg_field=message&_time_field=date
       format: json_lines
       json_date_format: iso8601
       compress: gzip
       log_response_payload: false
+      storage.total_limit_size: 256M

--- a/kubernetes/apps/observability/fluentbit/aggregator/pvc.yaml
+++ b/kubernetes/apps/observability/fluentbit/aggregator/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fluent-bit-aggregator-storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: openebs-hostpath

--- a/kubernetes/apps/observability/fluentbit/forwarder/helmrelease.yaml
+++ b/kubernetes/apps/observability/fluentbit/forwarder/helmrelease.yaml
@@ -23,6 +23,13 @@ spec:
     serviceMonitor:
       enabled: true
     logLevel: warn
+    priorityClassName: system-node-critical
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
     extraVolumes:
       - name: parsers
         configMap:

--- a/kubernetes/apps/observability/fluentbit/forwarder/pipelines/kubernetes-forwarder.yaml
+++ b/kubernetes/apps/observability/fluentbit/forwarder/pipelines/kubernetes-forwarder.yaml
@@ -3,7 +3,7 @@ pipeline:
     - name: tail
       alias: kubernetes
       path: /var/log/containers/*.log
-      parser: containerd
+      multiline.parser: cri
       tag: kubernetes.*
       skip_empty_lines: true
       skip_long_lines: false
@@ -13,6 +13,9 @@ pipeline:
       buffer_chunk_size: 128kb
       buffer_max_size: 256kb
       truncate_long_lines: true
+      db: /var/log/fluentbit/tail.db
+      db.sync: normal
+      storage.type: filesystem
 
   filters:
     - name: kubernetes
@@ -45,6 +48,12 @@ pipeline:
       rename: k_labels_app app
       rename: k_labels_k8s-app app
 
+    - name: record_modifier
+      match: '*'
+      remove_key:
+        - time
+        - _p
+
   outputs:
 
     - name: http
@@ -56,6 +65,7 @@ pipeline:
       json_date_format: iso8601
       compress: gzip
       log_response_payload: false
+      storage.total_limit_size: 1G
 
     #- name: kafka
     #  match: '*'


### PR DESCRIPTION
## What
Turns on filesystem buffering across the fluentbit pipeline: `storage.type: filesystem` on every input, a `storage.total_limit_size` per output, sqlite checkpoints for the tail and the events input, and a 1Gi PVC for the aggregator's buffer. Also sets requests/limits on both releases and switches the forwarder to the CRI multiline parser.

## Why
Everything buffered in memory, so a pod restart or a VictoriaLogs outage dropped whatever was in flight, and the forwarder's tail re-ingested from scratch on every start. With chunks on disk and offsets checkpointed, both survive a restart. The kubernetes events input already wrote a checkpoint db but had nowhere durable to put it.

## Changes
The forwarder is a DaemonSet, so its buffer and `tail.db` land on the node's `/var/log`, which the chart already mounts read-write — node state, not pod state. The aggregator is a single-replica Deployment, so it gets a PVC instead, and with that comes `updateStrategy: Recreate`: the claim is RWO on `openebs-hostpath`, and a rolling update would leave the new pod Pending on a volume the old one still holds. That pins the aggregator to one node, which is fine here — events and webhooks are reconstructible and the buffer is only transit.

`mem_buf_limit` sat in the `service` block doing nothing (it is an input property, and it is mutually exclusive with filesystem buffering), so it is gone; `storage.backlog.mem_limit` is the knob that actually applies.

## Test plan
- [x] `kustomize build kubernetes/apps/observability/fluentbit` renders clean with the PVC included
- [x] `helm template --set kind=Deployment --set updateStrategy.type=Recreate` confirms the chart maps it to the Deployment `strategy`
- [x] fluent-bit 5.1.2 locally with this config: storage root is created before inputs initialize, so `tail.db` needs no pre-existing directory
- [ ] after reconcile: both releases Ready, PVC Bound, no `dropped_records` on the storage metrics
- [ ] restart the forwarder and confirm it resumes from the checkpoint instead of re-ingesting

## Related
- Vikunja [#264](https://vikunja.oscaromeu.io/tasks/264)
- Notes: [Wiki › Observability › Fluentbit](https://docs.oscaromeu.io/doc/fluentbit-YuoiX5041o)

One open question for review: the kubernetes events output moved from `_time_field=lastTimestamp` to `date`, which means VictoriaLogs now stores ingest time rather than event time. If that was not deliberate it is a one-line revert.
