### PR TITLE
fix(cilium): add hubble context labels so the dashboards get data

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -34,12 +34,12 @@ spec:
       enabled: true
       metrics:
         enabled:
-          - dns
-          - drop
-          - flow
-          - icmp
+          - "dns:query;labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|pod|reserved-identity;destinationContext=workload-name|pod|dns|reserved-identity"
+          - "drop:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|pod|reserved-identity;destinationContext=workload-name|pod|dns|reserved-identity"
+          - "flow:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|pod|reserved-identity;destinationContext=workload-name|pod|dns|reserved-identity"
+          - "icmp:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|pod|reserved-identity;destinationContext=workload-name|pod|dns|reserved-identity"
+          - "tcp:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|pod|reserved-identity;destinationContext=workload-name|pod|dns|reserved-identity"
           - port-distribution
-          - tcp
           - "httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction"
         serviceMonitor:
           enabled: true
@@ -79,6 +79,8 @@ spec:
       rollOutPods: true
     prometheus:
       enabled: true
+      metrics:
+        - "+cilium_bpf_syscall_duration_seconds"
       serviceMonitor:
         enabled: true
         trustCRDsExist: true

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           - "icmp:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|pod|reserved-identity;destinationContext=workload-name|pod|dns|reserved-identity"
           - "tcp:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|pod|reserved-identity;destinationContext=workload-name|pod|dns|reserved-identity"
           - port-distribution
-          - "httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction"
+          - "httpV2:labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction"
         serviceMonitor:
           enabled: true
           trustCRDsExist: true


### PR DESCRIPTION
## What

Give the Hubble metric handlers the context options the shipped Grafana dashboards expect, and turn on the one opt-in agent metric the Cilium dashboard uses.

## Why

The config we started from is the one in the Cilium quickstart: it only sets `labelsContext` on `httpV2`. The two namespace dashboards (`hubble-dns-namespace`, `hubble-network-overview-namespace`) filter by `source_namespace`/`destination_namespace` and group by `source`/`destination`, and those labels simply do not exist on `flow`, `drop`, `tcp`, `icmp` and `dns` unless each handler is given `labelsContext` and `sourceContext`/`destinationContext`. The namespace dropdowns came up empty and every "Top 10" panel collapsed into a single unnamed series. The agent dashboard has the same problem with `cilium_bpf_syscall_duration_seconds`, which Cilium ships disabled.

## Changes

- `labelsContext=source_namespace,destination_namespace` plus `sourceContext`/`destinationContext` (`workload-name|pod|reserved-identity`, destination also falling back to `dns`) on dns, drop, flow, icmp and tcp.
- `dns:query` so the "Top 10 DNS queries" panel has a `query` label.
- `prometheus.metrics: ["+cilium_bpf_syscall_duration_seconds"]`.
- Dropped `exemplars=true` from `httpV2`. It was copied from the quickstart and never did anything: exemplars are only serialised with `hubble.metrics.enableOpenMetrics`, and Hubble only attaches one when the L7 request carries a `traceparent` header (`pkg/hubble/metrics/http/handler.go` reads `flow.TraceContext.Parent.TraceId`). Worth revisiting as a single change if we ever turn on L7.

## Test plan

`helm template` against the mirrored chart 1.18.6 renders `hubble-metrics` and `metrics` in the cilium ConfigMap as expected. Option names and values checked against `pkg/hubble/metrics/api/context.go` and `pkg/metrics/registry.go` on the v1.18.6 tag. Applying it rolls the cilium agents (`rollOutCiliumPods`).

## Out of scope

HTTP and DNS panels stay empty until there is a `CiliumNetworkPolicy` with L7 rules — Cilium only emits L7 flows for traffic a policy sends through the proxy, and the old visibility annotation is gone. Nothing here turns on L7; that means adding policies, and a CNP that pairs L7 rules with a blanket `toEntities: all` is exactly where the policy merge can take the proxy redirect away again. Worth trying in a throwaway namespace first.
