### PR TITLE
feat(observability): send every non-discogs alert to allquiet

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/config-alertmanager.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/config-alertmanager.yaml
@@ -17,8 +17,11 @@ spec:
       - receiver: allquiet
         continue: true
         matchers:
-          - name: alertname
-            value: E2EProbe.*
+          - name: alertgroup
+            value: Discogs
+            matchType: "!="
+          - name: severity
+            value: info|warning|critical
             matchType: =~
       - receiver: ch-archive
         continue: true


### PR DESCRIPTION
## What

The AllQuiet route stops being an allowlist of `E2EProbe.*` and takes every alert except the Discogs group.

## Why

Three probes are not enough traffic to exercise the triage flow, and the sandbox is where I try things out before they matter elsewhere. Discogs is the one group that stays out: those alerts are for me, they are already handled by their own Pushover receiver, and turning a record going on sale into an incident is not useful. Nothing about the destination changes — the receiver still posts to the webhook in `ALLQUIET_WEBHOOK_URL`, which points at the sandbox team.

## Changes

- `alertgroup != Discogs` on the AllQuiet route, so the group stays on Pushover
- `severity =~ info|warning|critical`, which also keeps `Watchdog` out: it is `severity: none` and fires permanently, so it would sit there as an incident that never resolves

## Test plan

`kustomize build kubernetes/apps/observability/kube-prometheus-stack/app` passes. After the merge, worth checking that a warning-level alert shows up in the sandbox team and that a Discogs alert still reaches Pushover only.
