### PR TITLE
feat(observability): title alerts with resource, namespace and cluster

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -49,3 +49,7 @@ spec:
     crds:
       enabled: true
     cleanPrometheusOperatorObjectNames: true
+    defaultRules:
+      additionalRuleGroupAnnotations:
+        kubernetesResources:
+          alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/values-prometheus.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/values-prometheus.yaml
@@ -26,6 +26,7 @@ prometheus:
     retentionSize: 15GB
     externalLabels:
       cluster: apps
+      env: homelab
     resources:
       requests:
         cpu: 100m

--- a/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/kube-prometheus.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/kube-prometheus.yaml
@@ -12,6 +12,7 @@ spec:
       rules:
         - alert: TargetDown
           annotations:
+            alert_title: 'TargetDown — {{ $labels.job }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.'
             runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/targetdown
             summary: One or more targets are unreachable.


### PR DESCRIPTION
What
----
Alert notifications now carry an `alert_title` annotation built from alertname,
the resource that broke, its namespace and the cluster/env pair, and `env` joins
`cluster` as a Prometheus external label.

Why
---
AllQuiet names an incident after the first non-empty Title mapping it resolves,
which today lands on `summary`. The upstream mixin summaries are fixed strings
with no labels in them, so nine different throttled containers all opened an
incident called "Processes experience elevated CPU throttling." — three of them
side by side in the inbox, impossible to tell apart without opening each one.
The discriminating detail lived in `description`, which nothing was reading.

The annotation is a separate key rather than an override of `summary` so the
title stays useful if the paging tool changes, and so the chart keeps rendering
its own summary untouched.

Changes
-------
- `values-prometheus.yaml`: add the `env: homelab` external label.
- `helmrelease.yaml`: set `alert_title` for the `kubernetesResources` rule group,
  which is where `CPUThrottlingHigh` lives.
- `monitoring/rules/kube-prometheus.yaml`: same annotation on `TargetDown`, as
  the first hand-written rule to adopt the format.

Test plan
---------
- `helm template` against chart 89.2.4 with these values renders `alert_title` on
  the eight `kubernetesResources` alerts, `CPUThrottlingHigh` among them.
- After the rollout, a firing alert should open an incident named
  `CPUThrottlingHigh — atuin · default · apps/homelab`.
- Adding `env` changes every fingerprint, so incidents already open will not
  receive their resolve event and need archiving once, by hand.

Out of scope
------------
The remaining 131 hand-written rules, and the duplication between the chart
`defaultRules` and `monitoring/rules/` — 79 alerts are currently defined twice.