### PR TITLE
feat(observability): build the alert title in alert relabeling

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -49,23 +49,3 @@ spec:
     crds:
       enabled: true
     cleanPrometheusOperatorObjectNames: true
-    defaultRules:
-      additionalRuleGroupAnnotations:
-        alertmanager: &alert_title
-          alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
-        configReloaders: *alert_title
-        etcd: *alert_title
-        general: *alert_title
-        kubeApiserverSlos: *alert_title
-        kubeControllerManager: *alert_title
-        kubeProxy: *alert_title
-        kubeSchedulerAlerting: *alert_title
-        kubeStateMetrics: *alert_title
-        kubernetesApps: *alert_title
-        kubernetesResources: *alert_title
-        kubernetesStorage: *alert_title
-        kubernetesSystem: *alert_title
-        network: *alert_title
-        nodeExporterAlerting: *alert_title
-        prometheus: *alert_title
-        prometheusOperator: *alert_title

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-e2e.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-e2e.yaml
@@ -12,7 +12,6 @@ spec:
       rules:
         - alert: E2EProbeFailed
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: E2E probe {{ $labels.job }} is failing.
             description: >-
               Probe {{ $labels.job }} ({{ $labels.env }}) reported

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-postgres.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-postgres.yaml
@@ -13,7 +13,6 @@ spec:
       rules:
         - alert: ExporterDown
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Crunchy postgres_exporter metrics are absent.
             description: >-
               No pg_up series is being scraped. The exporter sidecar or the
@@ -25,7 +24,6 @@ spec:
             severity: critical
         - alert: PGExporterScrapeError
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: postgres_exporter on {{ $labels.pod }} has scrape errors.
             description: >-
               The exporter is up but some monitoring queries fail, so part of
@@ -36,7 +34,6 @@ spec:
             severity: warning
         - alert: PGIsUp
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: PostgreSQL on {{ $labels.pod }} is not accepting connections.
           expr: pg_up < 1
           for: 1m
@@ -44,7 +41,6 @@ spec:
             severity: critical
         - alert: PGNoPrimary
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Cluster {{ $labels.pg_cluster }} has no primary instance.
           expr: max by (pg_cluster) (ccp_is_in_recovery_status) < 2
           for: 1m
@@ -52,7 +48,6 @@ spec:
             severity: critical
         - alert: PGClusterRoleChange
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Cluster {{ $labels.pg_cluster }} had a switchover/failover.
           expr: >-
             count by (pg_cluster) (ccp_is_in_recovery_status !=
@@ -62,7 +57,6 @@ spec:
             severity: warning
         - alert: PGConnPerc
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} ({{ $labels.pod }}) is using
               {{ $value | printf "%.0f" }}% of max_connections.
@@ -72,7 +66,6 @@ spec:
             severity: warning
         - alert: PGConnPerc
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} ({{ $labels.pod }}) is using
               {{ $value | printf "%.0f" }}% of max_connections.
@@ -82,7 +75,6 @@ spec:
             severity: critical
         - alert: PGDiskSize
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pod }} data disk ({{ $labels.mount_point }}) at
               {{ $value | printf "%.0f" }}%.
@@ -94,7 +86,6 @@ spec:
             severity: warning
         - alert: PGDiskSize
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pod }} data disk ({{ $labels.mount_point }}) at
               {{ $value | printf "%.0f" }}%.
@@ -106,7 +97,6 @@ spec:
             severity: critical
         - alert: DiskFillPredict
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pod }} data disk is predicted to fill within 24h at
               the current growth rate.
@@ -119,7 +109,6 @@ spec:
             severity: warning
         - alert: PGReplicationByteLag
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} has a replica lagging
               {{ $value | humanize1024 }}B behind the primary.
@@ -129,7 +118,6 @@ spec:
             severity: warning
         - alert: PGReplicationByteLag
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} has a replica lagging
               {{ $value | humanize1024 }}B behind the primary.
@@ -139,7 +127,6 @@ spec:
             severity: critical
         - alert: PGXIDWraparound
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} is {{ $value | printf "%.0f" }}% towards
               transaction ID wraparound.
@@ -149,7 +136,6 @@ spec:
             severity: warning
         - alert: PGXIDWraparound
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} is {{ $value | printf "%.0f" }}% towards
               transaction ID wraparound.
@@ -159,7 +145,6 @@ spec:
             severity: critical
         - alert: PGEmergencyVacuum
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} is {{ $value | printf "%.0f" }}% beyond
               autovacuum_freeze_max_age — autovacuum is not keeping up.
@@ -169,7 +154,6 @@ spec:
             severity: warning
         - alert: PGEmergencyVacuum
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} is {{ $value | printf "%.0f" }}% beyond
               autovacuum_freeze_max_age — autovacuum is not keeping up.
@@ -179,7 +163,6 @@ spec:
             severity: critical
         - alert: PGArchiveCommandStatus
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} has a recent archive_command failure —
               WAL archiving to pgBackRest is broken.
@@ -189,7 +172,6 @@ spec:
             severity: critical
         - alert: PGIdleTxn
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} has a session idle in transaction for
               over 15 minutes.
@@ -199,7 +181,6 @@ spec:
             severity: warning
         - alert: PGQueryTime
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} has a query running for over 24 hours.
           expr: ccp_connection_stats_max_query_time > 86400
@@ -208,7 +189,6 @@ spec:
             severity: warning
         - alert: PGSequenceExhaustion
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} has {{ $value }} sequence(s) over 75%
               used. Check SELECT * FROM monitor.sequence_status() WHERE percent >= 75.
@@ -218,7 +198,6 @@ spec:
             severity: warning
         - alert: PGSettingsPendingRestart
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               {{ $labels.pg_cluster }} has settings in pending_restart state.
           expr: ccp_settings_pending_restart_count > 0
@@ -231,7 +210,6 @@ spec:
         # incr hourly 2-23 (3h overnight gap), diff daily 01:00, full weekly Sun 01:00
         - alert: PGBackRestLastCompletedIncr
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               No pgBackRest incremental backup for {{ $labels.pg_cluster }} in
               {{ $value | humanizeDuration }} — the restore chain is going stale.
@@ -241,7 +219,6 @@ spec:
             severity: critical
         - alert: PGBackRestLastCompletedDiff
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               No pgBackRest differential backup for {{ $labels.pg_cluster }} in
               {{ $value | humanizeDuration }}.
@@ -251,7 +228,6 @@ spec:
             severity: critical
         - alert: PGBackRestLastCompletedFull
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               No pgBackRest full backup for {{ $labels.pg_cluster }} in
               {{ $value | humanizeDuration }}.
@@ -261,7 +237,6 @@ spec:
             severity: critical
         - alert: PGBackRestAbsentFull
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: >-
               pgBackRest backup metrics are absent — pgbackrest info is failing
               on the target, backup state is unknown.

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/values-prometheus.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/values-prometheus.yaml
@@ -27,6 +27,27 @@ prometheus:
     externalLabels:
       cluster: apps
       env: homelab
+    additionalAlertRelabelConfigs:
+      - source_labels: [alertname, cluster, env]
+        separator: ' · '
+        regex: '(.+) · (.+) · (.+)'
+        replacement: '$1 — $2/$3'
+        target_label: alert_title
+      - source_labels: [alertname, job, namespace, cluster, env]
+        separator: ' · '
+        regex: '(.+) · (.+) · (.+) · (.+) · (.+)'
+        replacement: '$1 — $2 · $3 · $4/$5'
+        target_label: alert_title
+      - source_labels: [alertname, pod, namespace, cluster, env]
+        separator: ' · '
+        regex: '(.+) · (.+) · (.+) · (.+) · (.+)'
+        replacement: '$1 — $2 · $3 · $4/$5'
+        target_label: alert_title
+      - source_labels: [alertname, container, namespace, cluster, env]
+        separator: ' · '
+        regex: '(.+) · (.+) · (.+) · (.+) · (.+)'
+        replacement: '$1 — $2 · $3 · $4/$5'
+        target_label: alert_title
     resources:
       requests:
         cpu: 100m

--- a/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/apiserver.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/apiserver.yaml
@@ -210,7 +210,6 @@ spec:
         severity: critical
         sloth_severity: page
       annotations:
-        alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
         runbook: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
         summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
           rate is over expected.'
@@ -234,7 +233,6 @@ spec:
         severity: warning
         sloth_severity: ticket
       annotations:
-        alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
         runbook: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
         summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
           rate is over expected.'
@@ -477,7 +475,6 @@ spec:
         severity: critical
         sloth_severity: page
       annotations:
-        alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
         runbook: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
         summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
           rate is over expected.'
@@ -501,7 +498,6 @@ spec:
         severity: warning
         sloth_severity: ticket
       annotations:
-        alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
         runbook: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
         summary: '{{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn
           rate is over expected.'

--- a/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/kube-prometheus.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/kube-prometheus.yaml
@@ -12,7 +12,6 @@ spec:
       rules:
         - alert: DeadMansSwitch
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             description: |
               This is an alert meant to ensure that the entire alerting pipeline is functional.
               This alert is always firing, therefore it should always be firing in Alertmanager

--- a/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/kubernetes-monitoring.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/kubernetes-monitoring.yaml
@@ -12,7 +12,6 @@ spec:
       rules:
         - alert: KubeJobCompletion
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than 12 hours to complete.
             runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubejobcompletion
             summary: Job did not complete in time
@@ -25,7 +24,6 @@ spec:
       rules:
         - alert: AggregatedAPIErrors
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             description: An aggregated API {{ $labels.name }}/{{ $labels.namespace }} has reported errors. It has appeared unavailable {{ $value | humanize }} times averaged over the past 10m.
             runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/aggregatedapierrors
             summary: An aggregated API has reported errors.
@@ -35,7 +33,6 @@ spec:
             severity: warning
         - alert: AggregatedAPIDown
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             description: An aggregated API {{ $labels.name }}/{{ $labels.namespace }} has been only {{ $value | humanize }}% available over the last 10m.
             runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/aggregatedapidown
             summary: An aggregated API is down.

--- a/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/node-exporter.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/node-exporter.yaml
@@ -12,7 +12,6 @@ spec:
       rules:
         - alert: NodeMachineIDCollision
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             description: Machine ID {{ $labels.id }} is duplicated among {{ $value }} nodes.
             summary: Machine ID collision.
           expr: |

--- a/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/thanos-query.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/thanos-query.yaml
@@ -18,7 +18,6 @@ spec:
           labels:
             severity: warning
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Thanos Query is not running
         - alert: ThanosQueryGrpcErrorRate
           expr: rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable",job="thanos-query-http"}[5m]) > 0
@@ -26,6 +25,5 @@ spec:
           labels:
             severity: warning
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Thanos Query is returning Internal/Unavailable errors
             description: Grafana is not showing metrics

--- a/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/thanos-store.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/thanos-store.yaml
@@ -17,7 +17,6 @@ spec:
           labels:
             severity: warning
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Thanos Store is returning Internal/Unavailable errors
             description: Long Term Storage Prometheus queries are failing
         - alert: ThanosStoreBucketOperationsFailed
@@ -26,7 +25,6 @@ spec:
           labels:
             severity: warning
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Thanos Store is failing to do bucket operations
             description: Long Term Storage Prometheus queries are failing
         - alert: ThanosStoreIsNotRunning
@@ -35,6 +33,5 @@ spec:
           labels:
             severity: warning
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Thanos Store is not running
             description: Long term storage queries will not work

--- a/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/turing-pi-thermal.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/monitoring/rules/turing-pi-thermal.yaml
@@ -12,7 +12,6 @@ spec:
       rules:
         - alert: TuringPiSoCTemperatureHigh
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Turing Pi SoC temperature high (early warning)
             description: >-
               SoC package temperature on {{ $labels.kubernetes_node }} is
@@ -25,7 +24,6 @@ spec:
             severity: warning
         - alert: TuringPiSoCTemperatureHigh
           annotations:
-            alert_title: '{{ $labels.alertname }} — {{ or $labels.container $labels.pod $labels.node $labels.instance $labels.job $labels.service "cluster" }} · {{ or $labels.namespace "-" }} · {{ $labels.cluster }}/{{ $labels.env }}'
             summary: Turing Pi SoC throttling (≥85 °C)
             description: >-
               SoC package temperature on {{ $labels.kubernetes_node }} is


### PR DESCRIPTION
Build `alert_title` in alert relabeling instead of a rule annotation, and
drop the annotation from the 42 rules that carry it.

### Why

The annotation could not work. `alertname` is attached to an alert after
its templates are evaluated, and `cluster` and `env` are external labels
injected on the way out to Alertmanager, so both rendered empty: every
title in the sandbox read `" — app · default · /"`.

### Changes

- Four `additionalAlertRelabelConfigs`, least to most specific; `(.+)`
  will not match an empty label, so each alert keeps the fullest title
  that matched
- `alert_title` gone from the hand-written rules and from
  `defaultRules.additionalRuleGroupAnnotations`

### Test plan

`helm template` renders the relabel secret with the four rules and the
Prometheus CR pointing at it, and `kustomize build monitoring/rules`
passes. After the merge, worth checking that a new incident reads
`CPUThrottlingHigh — app · default · apps/homelab`. The extra label
changes every fingerprint, so the incidents open now will not get their
resolve and need archiving once.

Supersedes the annotation added in #1236.