### PR TITLE
feat(observability): pick the alert resource before building the title

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/values-prometheus.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/values-prometheus.yaml
@@ -33,21 +33,59 @@ prometheus:
         regex: '(.+) · (.+) · (.+)'
         replacement: '$1 — $2/$3'
         target_label: alert_title
+      - source_labels: [node]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [instance]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [pod]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [container]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [resourcequota]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [persistentvolumeclaim]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [horizontalpodautoscaler]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [daemonset]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [statefulset]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [deployment]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [job_name]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [cronjob]
+        regex: '(.+)'
+        target_label: __resource
+      - source_labels: [alertname, __resource, cluster, env]
+        separator: ' · '
+        regex: '(.+) · (.+) · (.+) · (.+)'
+        replacement: '$1 — $2 · $3/$4'
+        target_label: alert_title
+      - source_labels: [alertname, __resource, namespace, cluster, env]
+        separator: ' · '
+        regex: '(.+) · (.+) · (.+) · (.+) · (.+)'
+        replacement: '$1 — $2 · $3 · $4/$5'
+        target_label: alert_title
       - source_labels: [alertname, job, namespace, cluster, env]
         separator: ' · '
-        regex: '(.+) · (.+) · (.+) · (.+) · (.+)'
-        replacement: '$1 — $2 · $3 · $4/$5'
+        regex: 'TargetDown · (.+) · (.+) · (.+) · (.+)'
+        replacement: 'TargetDown — $1 · $2 · $3/$4'
         target_label: alert_title
-      - source_labels: [alertname, pod, namespace, cluster, env]
-        separator: ' · '
-        regex: '(.+) · (.+) · (.+) · (.+) · (.+)'
-        replacement: '$1 — $2 · $3 · $4/$5'
-        target_label: alert_title
-      - source_labels: [alertname, container, namespace, cluster, env]
-        separator: ' · '
-        regex: '(.+) · (.+) · (.+) · (.+) · (.+)'
-        replacement: '$1 — $2 · $3 · $4/$5'
-        target_label: alert_title
+      - regex: __resource
+        action: labeldrop
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Choose the resource that goes in the title from a list of workload labels
instead of reading `job`, which on most alerts is the exporter rather
than the thing that broke.

### Why

The first real alert to come out of this showed the problem:
`KubeDeploymentReplicasMismatch` was titled `— kube-state-metrics ·
develop · apps/homelab`. The chain looked at `job` and found the
exporter that produced the series, not `foo-podinfo`, which is the
deployment short of replicas. `job` carries that meaning in 23 of the
chart alerts, so it was going to keep surfacing as the resource.

Doing it with one rule per label combination would need two dozen rules,
so the resource is picked into `__resource` first, least to most
specific, and the title is composed from it afterwards. That also
reaches the alerts the previous chain ignored entirely: quotas, PVCs,
HPAs, statefulsets and daemonsets. `cronjob` is in the list for the e2e
probes even though nothing here emits it yet.

### Changes

- Twelve rules filling `__resource`, from `node` up to `cronjob`, then
  two rules composing the title with and without a namespace
- `job` kept only for `TargetDown`, anchored on the alert name, since
  there the job is exactly what is down
- `__resource` dropped at the end

### Test plan

`helm template` of 89.2.4 renders the secret with the 17 rules in order.
Expected titles: `KubeDeploymentReplicasMismatch — foo-podinfo · develop
· apps/homelab`, `KubePodNotReady — foo-podinfo-... · develop ·
apps/homelab`, `CPUThrottlingHigh — app · default · apps/homelab`,
`TargetDown — atuin · default · apps/homelab`, `Watchdog — apps/homelab`.
The first three came from a real alert raised on purpose by pointing
`foo-podinfo` at a tag that does not exist.